### PR TITLE
Feature/explicit chunk nonce

### DIFF
--- a/src/main/java/org/cryptomator/cryptolib/api/FileContentCryptor.java
+++ b/src/main/java/org/cryptomator/cryptolib/api/FileContentCryptor.java
@@ -38,10 +38,10 @@ public interface FileContentCryptor {
 	 * @param cleartextChunk Content to be encrypted
 	 * @param chunkNumber Number of the chunk to be encrypted
 	 * @param header Header of the file, this chunk belongs to
-	 * @param nonce Nonce for this chunk
+	 * @param chunkNonce Nonce for this chunk
 	 * @return Encrypted content.
 	 */
-	ByteBuffer encryptChunk(ByteBuffer cleartextChunk, long chunkNumber, FileHeader header, byte[] nonce);
+	ByteBuffer encryptChunk(ByteBuffer cleartextChunk, long chunkNumber, FileHeader header, byte[] chunkNonce);
 
 	/**
 	 * Decrypts a single chunk of ciphertext.

--- a/src/main/java/org/cryptomator/cryptolib/api/FileContentCryptor.java
+++ b/src/main/java/org/cryptomator/cryptolib/api/FileContentCryptor.java
@@ -33,6 +33,17 @@ public interface FileContentCryptor {
 	ByteBuffer encryptChunk(ByteBuffer cleartextChunk, long chunkNumber, FileHeader header);
 
 	/**
+	 * Encrypts a single chunk of cleartext.
+	 *
+	 * @param cleartextChunk Content to be encrypted
+	 * @param chunkNumber Number of the chunk to be encrypted
+	 * @param header Header of the file, this chunk belongs to
+	 * @param nonce Nonce for this chunk
+	 * @return Encrypted content.
+	 */
+	ByteBuffer encryptChunk(ByteBuffer cleartextChunk, long chunkNumber, FileHeader header, byte[] nonce);
+
+	/**
 	 * Decrypts a single chunk of ciphertext.
 	 * 
 	 * @param ciphertextChunk Content to be decrypted

--- a/src/main/java/org/cryptomator/cryptolib/v1/FileContentCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v1/FileContentCryptorImpl.java
@@ -54,18 +54,18 @@ class FileContentCryptorImpl implements FileContentCryptor {
 
 	@Override
 	public ByteBuffer encryptChunk(ByteBuffer cleartextChunk, long chunkNumber, FileHeader header) {
-		byte[] nonce = new byte[NONCE_SIZE];
-		random.nextBytes(nonce);
-		return encryptChunk(cleartextChunk, chunkNumber, header, nonce);
+		byte[] chunkNonce = new byte[NONCE_SIZE];
+		random.nextBytes(chunkNonce);
+		return encryptChunk(cleartextChunk, chunkNumber, header, chunkNonce);
 	}
 
 	@Override
-	public ByteBuffer encryptChunk(ByteBuffer cleartextChunk, long chunkNumber, FileHeader header, byte[] nonce) {
+	public ByteBuffer encryptChunk(ByteBuffer cleartextChunk, long chunkNumber, FileHeader header, byte[] chunkNonce) {
 		if (cleartextChunk.remaining() == 0 || cleartextChunk.remaining() > PAYLOAD_SIZE) {
 			throw new IllegalArgumentException("Invalid chunk");
 		}
 		FileHeaderImpl headerImpl = FileHeaderImpl.cast(header);
-		return encryptChunk(cleartextChunk.asReadOnlyBuffer(), chunkNumber, headerImpl.getNonce(), nonce, headerImpl.getPayload().getContentKey());
+		return encryptChunk(cleartextChunk.asReadOnlyBuffer(), chunkNumber, headerImpl.getNonce(), chunkNonce, headerImpl.getPayload().getContentKey());
 	}
 
 	@Override

--- a/src/main/java/org/cryptomator/cryptolib/v1/FileContentCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v1/FileContentCryptorImpl.java
@@ -54,11 +54,18 @@ class FileContentCryptorImpl implements FileContentCryptor {
 
 	@Override
 	public ByteBuffer encryptChunk(ByteBuffer cleartextChunk, long chunkNumber, FileHeader header) {
+		byte[] nonce = new byte[NONCE_SIZE];
+		random.nextBytes(nonce);
+		return encryptChunk(cleartextChunk, chunkNumber, header, nonce);
+	}
+
+	@Override
+	public ByteBuffer encryptChunk(ByteBuffer cleartextChunk, long chunkNumber, FileHeader header, byte[] nonce) {
 		if (cleartextChunk.remaining() == 0 || cleartextChunk.remaining() > PAYLOAD_SIZE) {
 			throw new IllegalArgumentException("Invalid chunk");
 		}
 		FileHeaderImpl headerImpl = FileHeaderImpl.cast(header);
-		return encryptChunk(cleartextChunk.asReadOnlyBuffer(), chunkNumber, headerImpl.getNonce(), headerImpl.getPayload().getContentKey());
+		return encryptChunk(cleartextChunk.asReadOnlyBuffer(), chunkNumber, headerImpl.getNonce(), nonce, headerImpl.getPayload().getContentKey());
 	}
 
 	@Override
@@ -75,22 +82,18 @@ class FileContentCryptorImpl implements FileContentCryptor {
 	}
 
 	// visible for testing
-	ByteBuffer encryptChunk(ByteBuffer cleartextChunk, long chunkNumber, byte[] headerNonce, SecretKey fileKey) {
+	ByteBuffer encryptChunk(ByteBuffer cleartextChunk, long chunkNumber, byte[] headerNonce, byte[] chunkNonce, SecretKey fileKey) {
 		try {
-			// nonce:
-			byte[] nonce = new byte[NONCE_SIZE];
-			random.nextBytes(nonce);
-
 			// payload:
-			final Cipher cipher = CipherSupplier.AES_CTR.forEncryption(fileKey, new IvParameterSpec(nonce));
+			final Cipher cipher = CipherSupplier.AES_CTR.forEncryption(fileKey, new IvParameterSpec(chunkNonce));
 			final ByteBuffer outBuf = ByteBuffer.allocate(NONCE_SIZE + cipher.getOutputSize(cleartextChunk.remaining()) + MAC_SIZE);
-			outBuf.put(nonce);
+			outBuf.put(chunkNonce);
 			int bytesEncrypted = cipher.doFinal(cleartextChunk, outBuf);
 
 			// mac:
 			final ByteBuffer ciphertextBuf = outBuf.asReadOnlyBuffer();
 			ciphertextBuf.position(NONCE_SIZE).limit(NONCE_SIZE + bytesEncrypted);
-			byte[] authenticationCode = calcChunkMac(macKey, headerNonce, chunkNumber, nonce, ciphertextBuf);
+			byte[] authenticationCode = calcChunkMac(macKey, headerNonce, chunkNumber, chunkNonce, ciphertextBuf);
 			assert authenticationCode.length == MAC_SIZE;
 			outBuf.put(authenticationCode);
 

--- a/src/test/java/org/cryptomator/cryptolib/v1/FileContentCryptorImplBenchmark.java
+++ b/src/test/java/org/cryptomator/cryptolib/v1/FileContentCryptorImplBenchmark.java
@@ -40,6 +40,7 @@ public class FileContentCryptorImplBenchmark {
 	private static final SecretKey ENC_KEY = new SecretKeySpec(new byte[16], "AES");
 	private static final SecretKey MAC_KEY = new SecretKeySpec(new byte[16], "HmacSHA256");
 	private final byte[] headerNonce = new byte[Constants.NONCE_SIZE];
+	private final byte[] chunkNonce = new byte[Constants.NONCE_SIZE];
 	private final ByteBuffer cleartextChunk = ByteBuffer.allocate(Constants.PAYLOAD_SIZE);
 	private final ByteBuffer ciphertextChunk = ByteBuffer.allocate(Constants.CHUNK_SIZE);
 	private final FileContentCryptorImpl fileContentCryptor = new FileContentCryptorImpl(MAC_KEY, RANDOM_MOCK);
@@ -51,13 +52,14 @@ public class FileContentCryptorImplBenchmark {
 		cleartextChunk.rewind();
 		ciphertextChunk.rewind();
 		RANDOM_MOCK.nextBytes(headerNonce);
+		RANDOM_MOCK.nextBytes(chunkNonce);
 		RANDOM_MOCK.nextBytes(cleartextChunk.array());
 		RANDOM_MOCK.nextBytes(ciphertextChunk.array());
 	}
 
 	@Benchmark
 	public void benchmarkEncryption() {
-		fileContentCryptor.encryptChunk(cleartextChunk, chunkNumber, headerNonce, ENC_KEY);
+		fileContentCryptor.encryptChunk(cleartextChunk, chunkNumber, headerNonce, chunkNonce, ENC_KEY);
 	}
 
 	@Benchmark

--- a/src/test/java/org/cryptomator/cryptolib/v1/FileContentCryptorImplTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/v1/FileContentCryptorImplTest.java
@@ -58,7 +58,7 @@ public class FileContentCryptorImplTest {
 	@Test
 	public void testMacIsValidAfterEncryption() throws NoSuchAlgorithmException {
 		SecretKey fileKey = new SecretKeySpec(new byte[16], "AES");
-		ByteBuffer result = fileContentCryptor.encryptChunk(ByteBuffer.wrap("asd".getBytes()), 42l, new byte[16], fileKey);
+		ByteBuffer result = fileContentCryptor.encryptChunk(ByteBuffer.wrap("asd".getBytes()), 42l, new byte[16], new byte[16], fileKey);
 		Assert.assertTrue(fileContentCryptor.checkChunkMac(new byte[16], 42l, result));
 		Assert.assertFalse(fileContentCryptor.checkChunkMac(new byte[16], 43l, result));
 	}
@@ -66,7 +66,7 @@ public class FileContentCryptorImplTest {
 	@Test
 	public void testDecryptedEncryptedEqualsPlaintext() throws NoSuchAlgorithmException {
 		SecretKey fileKey = new SecretKeySpec(new byte[16], "AES");
-		ByteBuffer ciphertext = fileContentCryptor.encryptChunk(ByteBuffer.wrap("asd".getBytes()), 42l, new byte[16], fileKey);
+		ByteBuffer ciphertext = fileContentCryptor.encryptChunk(ByteBuffer.wrap("asd".getBytes()), 42l, new byte[16], new byte[16], fileKey);
 		ByteBuffer result = fileContentCryptor.decryptChunk(ciphertext, fileKey);
 		Assert.assertArrayEquals("asd".getBytes(), result.array());
 	}


### PR DESCRIPTION
We have a use case where we need to stream data  to calculate a checksum in advance and then transmit the exact same bytes to the server. Therefore we need to have an option in the API to make use of the same chunk nonces.