### PR TITLE
Added MasterkeyHubAccess 

### DIFF
--- a/src/main/java/org/cryptomator/cryptolib/common/MasterkeyHubAccess.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/MasterkeyHubAccess.java
@@ -10,6 +10,7 @@ import javax.crypto.AEADBadTagException;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
+import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
@@ -25,17 +26,17 @@ public class MasterkeyHubAccess {
 	/**
 	 * Decrypts a masterkey retrieved from Cryptomator Hub
 	 *
-	 * @param deviceKey         Key of the device this ciphertext is intended for
+	 * @param devicePrivateKey  Private key of the device this ciphertext is intended for
 	 * @param encodedCiphertext The encrypted masterkey
 	 * @param encodedEphPubKey  The ephemeral public key to be used to derive a secret shared between message sender and this device
 	 * @return The decrypted masterkey
 	 * @throws MasterkeyLoadingFailedException If the parameters don't match and decryption fails
 	 */
-	public static Masterkey decryptMasterkey(P384KeyPair deviceKey, String encodedCiphertext, String encodedEphPubKey) throws MasterkeyLoadingFailedException {
+	public static Masterkey decryptMasterkey(ECPrivateKey devicePrivateKey, String encodedCiphertext, String encodedEphPubKey) throws MasterkeyLoadingFailedException {
 		byte[] cleartext = new byte[0];
 		try {
 			EncryptedMessage message = decode(encodedCiphertext, encodedEphPubKey);
-			cleartext = ECIntegratedEncryptionScheme.HUB.decrypt(deviceKey.getPrivate(), message);
+			cleartext = ECIntegratedEncryptionScheme.HUB.decrypt(devicePrivateKey, message);
 			return new Masterkey(cleartext);
 		} catch (IllegalArgumentException | AEADBadTagException e) {
 			throw new MasterkeyLoadingFailedException("Key and ciphertext don't match", e);

--- a/src/main/java/org/cryptomator/cryptolib/common/MasterkeyHubAccess.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/MasterkeyHubAccess.java
@@ -1,0 +1,64 @@
+package org.cryptomator.cryptolib.common;
+
+import com.google.common.io.BaseEncoding;
+import org.cryptomator.cryptolib.api.Masterkey;
+import org.cryptomator.cryptolib.api.MasterkeyLoadingFailedException;
+import org.cryptomator.cryptolib.ecies.EncryptedMessage;
+import org.cryptomator.cryptolib.ecies.ECIntegratedEncryptionScheme;
+
+import javax.crypto.AEADBadTagException;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Arrays;
+
+public class MasterkeyHubAccess {
+
+	private static final BaseEncoding BASE64_URL = BaseEncoding.base64Url().omitPadding();
+
+	private MasterkeyHubAccess() {
+	}
+
+	/**
+	 * Decrypts a masterkey retrieved from Cryptomator Hub
+	 *
+	 * @param deviceKey         Key of the device this ciphertext is intended for
+	 * @param encodedCiphertext The encrypted masterkey
+	 * @param encodedEphPubKey  The ephemeral public key to be used to derive a secret shared between message sender and this device
+	 * @return The decrypted masterkey
+	 * @throws MasterkeyLoadingFailedException If the parameters don't match and decryption fails
+	 */
+	public static Masterkey decryptMasterkey(P384KeyPair deviceKey, String encodedCiphertext, String encodedEphPubKey) throws MasterkeyLoadingFailedException {
+		byte[] cleartext = new byte[0];
+		try {
+			EncryptedMessage message = decode(encodedCiphertext, encodedEphPubKey);
+			cleartext = ECIntegratedEncryptionScheme.HUB.decrypt(deviceKey.getPrivate(), message);
+			return new Masterkey(cleartext);
+		} catch (IllegalArgumentException | AEADBadTagException e) {
+			throw new MasterkeyLoadingFailedException("Key and ciphertext don't match", e);
+		} finally {
+			Arrays.fill(cleartext, (byte) 0x00);
+		}
+	}
+
+	private static EncryptedMessage decode(String encodedCiphertext, String encodedEphPubKey) throws IllegalArgumentException {
+		byte[] ciphertext = BASE64_URL.decode(encodedCiphertext);
+		byte[] keyBytes = BASE64_URL.decode(encodedEphPubKey);
+		try {
+			PublicKey key = KeyFactory.getInstance("EC").generatePublic(new X509EncodedKeySpec(keyBytes));
+			if (key instanceof ECPublicKey) {
+				return new EncryptedMessage((ECPublicKey) key, ciphertext);
+			} else {
+				throw new IllegalArgumentException("Key not an EC public key.");
+			}
+		} catch (InvalidKeySpecException e) {
+			throw new IllegalArgumentException("Invalid license public key", e);
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+}

--- a/src/main/java/org/cryptomator/cryptolib/common/MessageDigestSupplier.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/MessageDigestSupplier.java
@@ -14,6 +14,7 @@ import java.security.NoSuchAlgorithmException;
 public final class MessageDigestSupplier {
 
 	public static final MessageDigestSupplier SHA1 = new MessageDigestSupplier("SHA-1");
+	public static final MessageDigestSupplier SHA256 = new MessageDigestSupplier("SHA-256");
 
 	private final String digestAlgorithm;
 	private final ThreadLocal<MessageDigest> threadLocal;

--- a/src/main/java/org/cryptomator/cryptolib/common/P384KeyPair.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/P384KeyPair.java
@@ -33,7 +33,7 @@ public class P384KeyPair extends ECKeyPair {
 	 *
 	 * @param p12File    A .p12 file
 	 * @param passphrase The password to protect the key material
-	 * @return
+	 * @return loaded key pair
 	 * @throws IOException             In case of I/O errors
 	 * @throws Pkcs12PasswordException If the supplied password is incorrect
 	 * @throws Pkcs12Exception         If any cryptographic operation fails
@@ -49,7 +49,7 @@ public class P384KeyPair extends ECKeyPair {
 	 *
 	 * @param in         An input stream providing PKCS#12 formatted data
 	 * @param passphrase The password to protect the key material
-	 * @return
+	 * @return loaded key pair
 	 * @throws IOException             In case of I/O errors
 	 * @throws Pkcs12PasswordException If the supplied password is incorrect
 	 * @throws Pkcs12Exception         If any cryptographic operation fails

--- a/src/main/java/org/cryptomator/cryptolib/ecies/AuthenticatedEncryption.java
+++ b/src/main/java/org/cryptomator/cryptolib/ecies/AuthenticatedEncryption.java
@@ -1,0 +1,37 @@
+package org.cryptomator.cryptolib.ecies;
+
+import javax.crypto.AEADBadTagException;
+
+public interface AuthenticatedEncryption {
+
+	/**
+	 * AES-GCM with a 96 bit nonce taken from a the shared secret.
+	 *
+	 * Since the secret is derived via ECDH with an ephemeral key, the nonce is guaranteed to be unique.
+	 */
+	AuthenticatedEncryption GCM_WITH_SECRET_NONCE = new GcmWithSecretNonce();
+
+	/**
+	 * @return number of bytes required during {@link #encrypt(byte[], byte[])} and {@link #decrypt(byte[], byte[])}
+	 */
+	int requiredSecretBytes();
+
+	/**
+	 * Encrypts the given <code>plaintext</code>
+	 *
+	 * @param secret    secret data required for encryption, such as (but not limited to) a key
+	 * @param plaintext The data to encrypt
+	 * @return The encrypted data, including all required information for authentication, such as a tag
+	 */
+	byte[] encrypt(byte[] secret, byte[] plaintext);
+
+	/**
+	 * Encrypts the given <code>ciphertext</code>
+	 *
+	 * @param secret     secret data required for encryption, such as (but not limited to) a key
+	 * @param ciphertext The data to decrypt
+	 * @return The decrypted data
+	 * @throws AEADBadTagException In case of an authentication failure (including wrong <code>secret</code>)
+	 */
+	byte[] decrypt(byte[] secret, byte[] ciphertext) throws AEADBadTagException;
+}

--- a/src/main/java/org/cryptomator/cryptolib/ecies/ECIntegratedEncryptionScheme.java
+++ b/src/main/java/org/cryptomator/cryptolib/ecies/ECIntegratedEncryptionScheme.java
@@ -22,7 +22,7 @@ public class ECIntegratedEncryptionScheme {
 	 *     <li>Cut shared secret into 256 bit key + 96 bit nonce used for AES-GCM to encrypt/decrypt</li>
 	 * </ul>
 	 */
-	public static ECIntegratedEncryptionScheme HUB = new ECIntegratedEncryptionScheme(AuthenticatedEncryption.GCM_WITH_SECRET_NONCE, KeyDerivationFunction.ANSI_X963_SHA256_KDF);
+	public static final ECIntegratedEncryptionScheme HUB = new ECIntegratedEncryptionScheme(AuthenticatedEncryption.GCM_WITH_SECRET_NONCE, KeyDerivationFunction.ANSI_X963_SHA256_KDF);
 
 	private final AuthenticatedEncryption ae;
 	private final KeyDerivationFunction kdf;

--- a/src/main/java/org/cryptomator/cryptolib/ecies/ECIntegratedEncryptionScheme.java
+++ b/src/main/java/org/cryptomator/cryptolib/ecies/ECIntegratedEncryptionScheme.java
@@ -1,0 +1,90 @@
+package org.cryptomator.cryptolib.ecies;
+
+import org.cryptomator.cryptolib.common.Destroyables;
+
+import javax.crypto.AEADBadTagException;
+import javax.crypto.KeyAgreement;
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.util.Arrays;
+
+public class ECIntegratedEncryptionScheme {
+
+	/**
+	 * The ECIES used in Cryptomator Hub:
+	 * <ul>
+	 *     <li>To be used with {@link org.cryptomator.cryptolib.common.P384KeyPair P-384 EC keys}</li>
+	 *     <li>Use ANSI X9.63 KDF with SHA-256 to derive a 352 bit shared secret</li>
+	 *     <li>Cut shared secret into 256 bit key + 96 bit nonce used for AES-GCM to encrypt/decrypt</li>
+	 * </ul>
+	 */
+	public static ECIntegratedEncryptionScheme HUB = new ECIntegratedEncryptionScheme(AuthenticatedEncryption.GCM_WITH_SECRET_NONCE, KeyDerivationFunction.ANSI_X963_SHA256_KDF);
+
+	private final AuthenticatedEncryption ae;
+	private final KeyDerivationFunction kdf;
+
+	public ECIntegratedEncryptionScheme(AuthenticatedEncryption ae, KeyDerivationFunction kdf) {
+		this.ae = ae;
+		this.kdf = kdf;
+	}
+
+	public EncryptedMessage encrypt(KeyPairGenerator ephKeyGen, ECPublicKey receiverPublicKey, byte[] plaintext) {
+		KeyPair ephKeyPair = ephKeyGen.generateKeyPair();
+		try {
+			if (ephKeyPair.getPrivate() instanceof ECPrivateKey) {
+				assert ephKeyPair.getPublic() instanceof ECPublicKey;
+				byte[] ciphertext = encrypt((ECPrivateKey) ephKeyPair.getPrivate(), receiverPublicKey, plaintext);
+				return new EncryptedMessage((ECPublicKey) ephKeyPair.getPublic(), ciphertext);
+			} else {
+				throw new IllegalArgumentException("key generator didn't create EC key pair");
+			}
+		} finally {
+			Destroyables.destroySilently(ephKeyPair.getPrivate());
+		}
+	}
+
+	public byte[] decrypt(ECPrivateKey receiverPrivateKey, EncryptedMessage encryptedMessage) throws AEADBadTagException {
+		return decrypt(receiverPrivateKey, encryptedMessage.getEphPublicKey(), encryptedMessage.getCiphertext());
+	}
+
+	// visible for testing
+	byte[] encrypt(ECPrivateKey ephPrivateKey, ECPublicKey receiverPublicKey, byte[] plaintext) {
+		byte[] secret = ecdhAndKdf(ephPrivateKey, receiverPublicKey, ae.requiredSecretBytes());
+		return ae.encrypt(secret, plaintext);
+	}
+
+	// visible for testing
+	byte[] decrypt(ECPrivateKey receiverPrivateKey, ECPublicKey ephPublicKey, byte[] plaintext) throws AEADBadTagException {
+		byte[] secret = ecdhAndKdf(receiverPrivateKey, ephPublicKey, ae.requiredSecretBytes());
+		return ae.decrypt(secret, plaintext);
+	}
+
+	private byte[] ecdhAndKdf(ECPrivateKey privateKey, ECPublicKey publicKey, int numBytes) {
+		byte[] sharedSecret = new byte[0];
+		try {
+			KeyAgreement keyAgreement = createKeyAgreement();
+			keyAgreement.init(privateKey);
+			keyAgreement.doPhase(publicKey, true);
+			sharedSecret = keyAgreement.generateSecret();
+			return kdf.deriveKey(sharedSecret, numBytes);
+		} catch (InvalidKeyException e) {
+			throw new IllegalArgumentException("Invalid keys", e);
+		} finally {
+			Arrays.fill(sharedSecret, (byte) 0x00);
+		}
+	}
+
+	private static KeyAgreement createKeyAgreement() {
+		try {
+			return KeyAgreement.getInstance("ECDH");
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException("ECDH not supported");
+		}
+	}
+
+
+}

--- a/src/main/java/org/cryptomator/cryptolib/ecies/EncryptedMessage.java
+++ b/src/main/java/org/cryptomator/cryptolib/ecies/EncryptedMessage.java
@@ -1,0 +1,23 @@
+package org.cryptomator.cryptolib.ecies;
+
+import java.security.interfaces.ECPublicKey;
+
+public class EncryptedMessage {
+
+	private final ECPublicKey ephPublicKey;
+	private final byte[] ciphertext;
+
+	public EncryptedMessage(ECPublicKey ephPublicKey, byte[] ciphertext) {
+		this.ephPublicKey = ephPublicKey;
+		this.ciphertext = ciphertext;
+	}
+
+	public ECPublicKey getEphPublicKey() {
+		return ephPublicKey;
+	}
+
+	public byte[] getCiphertext() {
+		return ciphertext;
+	}
+
+}

--- a/src/main/java/org/cryptomator/cryptolib/ecies/GcmWithSecretNonce.java
+++ b/src/main/java/org/cryptomator/cryptolib/ecies/GcmWithSecretNonce.java
@@ -1,8 +1,6 @@
 package org.cryptomator.cryptolib.ecies;
 
 import com.google.common.base.Throwables;
-import org.cryptomator.cryptolib.api.Masterkey;
-import org.cryptomator.cryptolib.api.MasterkeyLoadingFailedException;
 import org.cryptomator.cryptolib.common.CipherSupplier;
 import org.cryptomator.cryptolib.common.DestroyableSecretKey;
 

--- a/src/main/java/org/cryptomator/cryptolib/ecies/GcmWithSecretNonce.java
+++ b/src/main/java/org/cryptomator/cryptolib/ecies/GcmWithSecretNonce.java
@@ -1,0 +1,49 @@
+package org.cryptomator.cryptolib.ecies;
+
+import com.google.common.base.Throwables;
+import org.cryptomator.cryptolib.api.Masterkey;
+import org.cryptomator.cryptolib.api.MasterkeyLoadingFailedException;
+import org.cryptomator.cryptolib.common.CipherSupplier;
+import org.cryptomator.cryptolib.common.DestroyableSecretKey;
+
+import javax.crypto.AEADBadTagException;
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.spec.GCMParameterSpec;
+import java.util.Arrays;
+
+class GcmWithSecretNonce implements AuthenticatedEncryption {
+
+	private static final int GCM_KEY_SIZE = 32;
+	private static final int GCM_TAG_SIZE = 16;
+	private static final int GCM_NONCE_SIZE = 12; // 96 bit IVs strongly recommended for GCM
+
+	@Override
+	public int requiredSecretBytes() {
+		return GCM_KEY_SIZE + GCM_NONCE_SIZE;
+	}
+
+	@Override
+	public byte[] encrypt(byte[] secret, byte[] plaintext) {
+		try (DestroyableSecretKey key = new DestroyableSecretKey(secret, 0, GCM_KEY_SIZE, "AES")) {
+			byte[] nonce = Arrays.copyOfRange(secret, GCM_KEY_SIZE, GCM_KEY_SIZE + GCM_NONCE_SIZE);
+			Cipher cipher = CipherSupplier.AES_GCM.forEncryption(key, new GCMParameterSpec(GCM_TAG_SIZE * Byte.SIZE, nonce));
+			return cipher.doFinal(plaintext);
+		} catch (IllegalBlockSizeException | BadPaddingException e) {
+			throw new IllegalStateException("Unexpected exception during GCM decryption.", e);
+		}
+	}
+
+	@Override
+	public byte[] decrypt(byte[] secret, byte[] ciphertext) throws AEADBadTagException {
+		try (DestroyableSecretKey key = new DestroyableSecretKey(secret, 0, GCM_KEY_SIZE, "AES")) {
+			byte[] nonce = Arrays.copyOfRange(secret, GCM_KEY_SIZE, GCM_KEY_SIZE + GCM_NONCE_SIZE);
+			Cipher cipher = CipherSupplier.AES_GCM.forDecryption(key, new GCMParameterSpec(GCM_TAG_SIZE * Byte.SIZE, nonce));
+			return cipher.doFinal(ciphertext);
+		} catch (IllegalBlockSizeException | BadPaddingException e) {
+			Throwables.throwIfInstanceOf(e, AEADBadTagException.class);
+			throw new IllegalStateException("Unexpected exception during GCM decryption.", e);
+		}
+	}
+}

--- a/src/main/java/org/cryptomator/cryptolib/ecies/KeyDerivationFunction.java
+++ b/src/main/java/org/cryptomator/cryptolib/ecies/KeyDerivationFunction.java
@@ -1,0 +1,64 @@
+package org.cryptomator.cryptolib.ecies;
+
+import org.cryptomator.cryptolib.common.MessageDigestSupplier;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.security.DigestException;
+import java.security.MessageDigest;
+import java.util.Arrays;
+
+@FunctionalInterface
+public interface KeyDerivationFunction {
+
+	KeyDerivationFunction ANSI_X963_SHA256_KDF = (sharedSecret, keyDataLen) -> ansiX963sha256Kdf(sharedSecret, new byte[0], keyDataLen);
+
+	/**
+	 * Derives a key of desired length
+	 *
+	 * @param sharedSecret A shared secret
+	 * @param keyDataLen   Desired key length (in bytes)
+	 * @return key data
+	 */
+	byte[] deriveKey(byte[] sharedSecret, int keyDataLen);
+
+	/**
+	 * Performs <a href="https://www.secg.org/sec1-v2.pdf">ANSI-X9.63-KDF</a> with SHA-256
+	 *
+	 * @param sharedSecret A shared secret
+	 * @param sharedInfo   Additional authenticated data
+	 * @param keyDataLen   Desired key length (in bytes)
+	 * @return key data
+	 */
+	static byte[] ansiX963sha256Kdf(byte[] sharedSecret, byte[] sharedInfo, int keyDataLen) {
+		MessageDigest digest = MessageDigestSupplier.SHA256.get(); // max input length is 2^64 - 1, see https://doi.org/10.6028/NIST.SP.800-56Cr2, Table 1
+		int hashLen = digest.getDigestLength();
+
+		// These two checks must be performed according to spec. However with 32 bit integers, we can't exceed any limits anyway:
+		assert BigInteger.valueOf(sharedSecret.length + sharedInfo.length + 4).compareTo(BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE)) < 0 : "input larger than hashmaxlen";
+		assert keyDataLen < (2L << 32 - 1) * hashLen : "keyDataLen larger than hashLen × (2^32 − 1)";
+
+		ByteBuffer counter = ByteBuffer.allocate(Integer.BYTES);
+		assert ByteOrder.BIG_ENDIAN.equals(counter.order());
+		int n = (keyDataLen + hashLen - 1) / hashLen;
+		byte[] buffer = new byte[n * hashLen];
+		try {
+			for (int i = 0; i < n; i++) {
+				digest.update(sharedSecret);
+				counter.clear();
+				counter.putInt(i + 1);
+				counter.flip();
+				digest.update(counter);
+				digest.update(sharedInfo);
+				digest.digest(buffer, i * hashLen, hashLen);
+			}
+			return Arrays.copyOf(buffer, keyDataLen);
+		} catch (DigestException e) {
+			throw new IllegalStateException("Invalid digest output buffer offset", e);
+		} finally {
+			Arrays.fill(buffer, (byte) 0x00);
+		}
+	}
+
+}

--- a/src/main/java/org/cryptomator/cryptolib/ecies/KeyDerivationFunction.java
+++ b/src/main/java/org/cryptomator/cryptolib/ecies/KeyDerivationFunction.java
@@ -36,7 +36,7 @@ public interface KeyDerivationFunction {
 		int hashLen = digest.getDigestLength();
 
 		// These two checks must be performed according to spec. However with 32 bit integers, we can't exceed any limits anyway:
-		assert BigInteger.valueOf(sharedSecret.length + sharedInfo.length + 4).compareTo(BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE)) < 0 : "input larger than hashmaxlen";
+		assert BigInteger.valueOf(sharedSecret.length + sharedInfo.length + 4l).compareTo(BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE)) < 0 : "input larger than hashmaxlen";
 		assert keyDataLen < (2L << 32 - 1) * hashLen : "keyDataLen larger than hashLen × (2^32 − 1)";
 
 		ByteBuffer counter = ByteBuffer.allocate(Integer.BYTES);

--- a/src/main/java/org/cryptomator/cryptolib/ecies/KeyDerivationFunction.java
+++ b/src/main/java/org/cryptomator/cryptolib/ecies/KeyDerivationFunction.java
@@ -36,8 +36,8 @@ public interface KeyDerivationFunction {
 		int hashLen = digest.getDigestLength();
 
 		// These two checks must be performed according to spec. However with 32 bit integers, we can't exceed any limits anyway:
-		assert BigInteger.valueOf(sharedSecret.length + sharedInfo.length + 4l).compareTo(BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE)) < 0 : "input larger than hashmaxlen";
-		assert keyDataLen < (2L << 32 - 1) * hashLen : "keyDataLen larger than hashLen × (2^32 − 1)";
+		assert BigInteger.valueOf(4L + sharedSecret.length + sharedInfo.length).compareTo(BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE)) < 0 : "input larger than hashmaxlen";
+		assert keyDataLen < (1L << 32 - 1) * hashLen : "keyDataLen larger than hashLen × (2^32 − 1)";
 
 		ByteBuffer counter = ByteBuffer.allocate(Integer.BYTES);
 		assert ByteOrder.BIG_ENDIAN.equals(counter.order());

--- a/src/test/java/org/cryptomator/cryptolib/common/MasterkeyHubAccessTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/common/MasterkeyHubAccessTest.java
@@ -8,37 +8,21 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Arrays;
 
 public class MasterkeyHubAccessTest {
 
-	private static final byte[] DEVICE_PKCS12 = BaseEncoding.base64Url().decode("MIIFhAIBAzCCBT0GCSqGSIb3DQEHAaCCBS" //
-			+ "4EggUqMIIFJjCB6wYJKoZIhvcNAQcBoIHdBIHaMIHXMIHUBgsqhkiG9w0BDAoBAqCBiDCBhTApBgoqhkiG9w0BDAEDMBsEFGAM85ETk7ydc" //
-			+ "BZlJOEO4_4t7LcGAgMAw1AEWLu-1SdjZkqjOdwiQBOFYJkrtZimD0AHst3LxOmdVJZGJ2my4hgxQJH2sIcEnpNwQnrlBcI80xy4bozDxZ6W" //
-			+ "Asu-BymbjAqg86xpB6XBIQZj9NQ24OA1NuwxOjAVBgkqhkiG9w0BCRQxCB4GAGsAZQB5MCEGCSqGSIb3DQEJFTEUBBJUaW1lIDE2MjkzNjg" //
-			+ "wNjExMzIwggQ0BgkqhkiG9w0BBwagggQlMIIEIQIBADCCBBoGCSqGSIb3DQEHATApBgoqhkiG9w0BDAEGMBsEFOAPMGdG_k1brTiSEjOV1P" //
-			+ "X4bu8MAgMAw1CAggPgHpg-v843nCYSn9TPMR11UHT2puRiD-xo8CeHxavkEUZDZOwfk9E0Clhq7ibejxW7GgY3gmPxU9OvZNmXdGY6cI_7h" //
-			+ "icyX6Ftvl2iZSouSDEpzzpFFut3zSjaY3T8VU0YbT2f1Kw_4EQRmr0QQxBLfp6mbcLyy4sPPB-n3Yej9LRU5_aa6MFYrWdw4chO3T1246v1" //
-			+ "GqhvHvnpwXk989Rt0RFau57oV4Y2BWuYF5tL5njy0svOfWi9lL3k8NhezcBmzSm42JP69OLZE34tQNDhGWIkLn1XyALEHEJz6IcbRs-yAoB" //
-			+ "S362cQFgrSKRjXnrLoPVYZMQOhlexBL4A2kuvNCF-DNEgoWUdHI1EkCUODV8a3gAFwucCsMpDBnwlU7AVMF75X2gWENG-MUd2bSWj6qK53y" //
-			+ "iyqEjYguBp8Xxibi_jniX6Y9L-1xa5Q3ccthcjFXCne3l3-KXW3Nr98j6u6jz6HtJbblvUb_J4Y1R3M35s1380Qv80zvkUpkUHoCSbDFhY8" //
-			+ "cikj5W3oE6wlfUhRjfmKzKZOrMuIoMqBkUA6rpEpq666_zOoD-Cxay62HjWWiueTiELKEtbe-Dq8_dqX5LZ27P2wWEiOXInv8pKKiHAxSQn" //
-			+ "qzn7FOH7KCh4u-cMemi-0itjP6KFbW_dpg0cca6RHyIPSCUejlyvfr0Spewf9D2q3j7iTK1QZL_nQck2TcdeVjE7_PpwX3hPDGtt9PFYFBL" //
-			+ "4od93JmcutaRXm0iXUNkBwwXf53Eiw8vTRwPkdJ-w6z6Bl4jjWMS5yDPPx--UscCooEgGJOpJivTFGwaa2f-vt4N4P0jfA2vZVIrz1II-T8" //
-			+ "O8DaVw7TtgsgfDm8DBXyoCESXY37ss58NVOWsqSgF8-TD4Rzpy2DCb9NC5tn_wLCt2vErg8veWVrNo99fXqOdDI0ymoEyqUB2sKqcDfIo0s" //
-			+ "mB_DFbcxmqFNG9tsS9O7Lg3L045eZlnM6u0G2hmPcOw5aHhZ3ZhL2s7S46-EJSvvYqLTlB2KTH-ww6JnftiEmKva6ABUuhmCD101XSFg0rh" //
-			+ "eYFFxtoIbFVXC7V6L3tv3IbSmI-jWDapJYgYjDapmBLaGRJyEU_oxILOPJEKvQnPdRORcNsYuKc3QZXLMKkTC1XtOzal6I5w_HcXPu8y19y" //
-			+ "ZpPP0NAl-QwFVI2s4Ch7UJYP-cbRee4sJzKzmLG7vM8_NrJLH_m-ecLqh2ahHpc4W-7bqbNJnbJ9E8Cvm4urGxTeyTlz3boGoBJXbtQx67T" //
-			+ "1bvj1Z-bFvOcSrX7UfDb-NMIaK09wxOyFO6wTD6B_VOEyChFuv0wWMLaYwPjAhMAkGBSsOAwIaBQAEFP9S30F1lPqFdDzVCTDtH1gXqITXB" //
-			+ "BSXiYwuLjMqaiwdT_Xbi0ue97zSVQIDAYag");
-
-	private P384KeyPair deviceKey;
+	private ECPrivateKey devicePrivateKey;
 
 	@BeforeEach
-	public void setup() throws IOException {
-		this.deviceKey = P384KeyPair.load(new ByteArrayInputStream(DEVICE_PKCS12), "secret".toCharArray());
+	public void setup() throws NoSuchAlgorithmException, InvalidKeySpecException {
+		byte[] keyBytes = BaseEncoding.base64Url().decode("ME4CAQAwEAYHKoZIzj0CAQYFK4EEACIENzA1AgEBBDDzj9mBnoqoYTO0wQDvM2iyI2wrNe468US1mHMjdJcKWGGvky4pMexIvmvmDsZLdsY");
+		this.devicePrivateKey = (ECPrivateKey) KeyFactory.getInstance("EC").generatePrivate(new PKCS8EncodedKeySpec(keyBytes));
 	}
 
 	@Test
@@ -47,7 +31,7 @@ public class MasterkeyHubAccessTest {
 		String ephPk = "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEkcv3x-hkCnb8Kr8TNfaLpD4q64ZqPn4p1yuM8r2r16h6f6mG01kFBp2EoY575bCcmT54PxiDFkf3KKqHXFjZwBhdm6zMp22l37ZlmKyHG96vkB7Rh6qFyzEhSQ_nvl2G";
 		String ciphertext = "KQ48XS6ziW3tS7SMLR5sc2o_Y80OR4SS_htHpk8SHn4KrqI07EtDFFbNJ9AcNOazSu3TXrml--t_bEXprfnPqa3MlBvmPUVBcwUFJPDTR9Y";
 
-		Masterkey masterkey = MasterkeyHubAccess.decryptMasterkey(deviceKey, ciphertext, ephPk);
+		Masterkey masterkey = MasterkeyHubAccess.decryptMasterkey(devicePrivateKey, ciphertext, ephPk);
 
 		byte[] expectedKey = new byte[64];
 		Arrays.fill(expectedKey, 0, 32, (byte) 0x55);
@@ -62,7 +46,7 @@ public class MasterkeyHubAccessTest {
 		String ciphertext = "KQ48XS6ziW3tS7SMLR5sc2o_Y80OR4SS_htHpk8SHn4KrqI07EtDFFbNJ9AcNOazSu3TXrml--t_bEXprfnPqa3MlBvmPUVBcwUFJPDTR9Y";
 
 		Assertions.assertThrows(MasterkeyLoadingFailedException.class, () -> {
-			MasterkeyHubAccess.decryptMasterkey(deviceKey, ciphertext, ephPk);
+			MasterkeyHubAccess.decryptMasterkey(devicePrivateKey, ciphertext, ephPk);
 		});
 	}
 
@@ -73,7 +57,7 @@ public class MasterkeyHubAccessTest {
 		String ciphertext = "kQ48XS6ziW3tS7SMLR5sc2o_Y80OR4SS_htHpk8SHn4KrqI07EtDFFbNJ9AcNOazSu3TXrml--t_bEXprfnPqa3MlBvmPUVBcwUFJPDTR9Y";
 
 		Assertions.assertThrows(MasterkeyLoadingFailedException.class, () -> {
-			MasterkeyHubAccess.decryptMasterkey(deviceKey, ciphertext, ephPk);
+			MasterkeyHubAccess.decryptMasterkey(devicePrivateKey, ciphertext, ephPk);
 		});
 	}
 
@@ -82,7 +66,7 @@ public class MasterkeyHubAccessTest {
 	public void testDecryptWithInvalidDeviceKey() {
 		String ephPk = "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEkcv3x-hkCnb8Kr8TNfaLpD4q64ZqPn4p1yuM8r2r16h6f6mG01kFBp2EoY575bCcmT54PxiDFkf3KKqHXFjZwBhdm6zMp22l37ZlmKyHG96vkB7Rh6qFyzEhSQ_nvl2G";
 		String ciphertext = "KQ48XS6ziW3tS7SMLR5sc2o_Y80OR4SS_htHpk8SHn4KrqI07EtDFFbNJ9AcNOazSu3TXrml--t_bEXprfnPqa3MlBvmPUVBcwUFJPDTR9Y";
-		P384KeyPair wrongKey = P384KeyPair.generate();
+		ECPrivateKey wrongKey = P384KeyPair.generate().getPrivate();
 
 		Assertions.assertThrows(MasterkeyLoadingFailedException.class, () -> {
 			MasterkeyHubAccess.decryptMasterkey(wrongKey, ciphertext, ephPk);

--- a/src/test/java/org/cryptomator/cryptolib/common/MasterkeyHubAccessTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/common/MasterkeyHubAccessTest.java
@@ -1,0 +1,92 @@
+package org.cryptomator.cryptolib.common;
+
+import com.google.common.io.BaseEncoding;
+import org.cryptomator.cryptolib.api.Masterkey;
+import org.cryptomator.cryptolib.api.MasterkeyLoadingFailedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class MasterkeyHubAccessTest {
+
+	private static final byte[] devicePkcs12 = BaseEncoding.base64Url().decode("MIIFhAIBAzCCBT0GCSqGSIb3DQEHAaCCBS" //
+			+ "4EggUqMIIFJjCB6wYJKoZIhvcNAQcBoIHdBIHaMIHXMIHUBgsqhkiG9w0BDAoBAqCBiDCBhTApBgoqhkiG9w0BDAEDMBsEFGAM85ETk7ydc" //
+			+ "BZlJOEO4_4t7LcGAgMAw1AEWLu-1SdjZkqjOdwiQBOFYJkrtZimD0AHst3LxOmdVJZGJ2my4hgxQJH2sIcEnpNwQnrlBcI80xy4bozDxZ6W" //
+			+ "Asu-BymbjAqg86xpB6XBIQZj9NQ24OA1NuwxOjAVBgkqhkiG9w0BCRQxCB4GAGsAZQB5MCEGCSqGSIb3DQEJFTEUBBJUaW1lIDE2MjkzNjg" //
+			+ "wNjExMzIwggQ0BgkqhkiG9w0BBwagggQlMIIEIQIBADCCBBoGCSqGSIb3DQEHATApBgoqhkiG9w0BDAEGMBsEFOAPMGdG_k1brTiSEjOV1P" //
+			+ "X4bu8MAgMAw1CAggPgHpg-v843nCYSn9TPMR11UHT2puRiD-xo8CeHxavkEUZDZOwfk9E0Clhq7ibejxW7GgY3gmPxU9OvZNmXdGY6cI_7h" //
+			+ "icyX6Ftvl2iZSouSDEpzzpFFut3zSjaY3T8VU0YbT2f1Kw_4EQRmr0QQxBLfp6mbcLyy4sPPB-n3Yej9LRU5_aa6MFYrWdw4chO3T1246v1" //
+			+ "GqhvHvnpwXk989Rt0RFau57oV4Y2BWuYF5tL5njy0svOfWi9lL3k8NhezcBmzSm42JP69OLZE34tQNDhGWIkLn1XyALEHEJz6IcbRs-yAoB" //
+			+ "S362cQFgrSKRjXnrLoPVYZMQOhlexBL4A2kuvNCF-DNEgoWUdHI1EkCUODV8a3gAFwucCsMpDBnwlU7AVMF75X2gWENG-MUd2bSWj6qK53y" //
+			+ "iyqEjYguBp8Xxibi_jniX6Y9L-1xa5Q3ccthcjFXCne3l3-KXW3Nr98j6u6jz6HtJbblvUb_J4Y1R3M35s1380Qv80zvkUpkUHoCSbDFhY8" //
+			+ "cikj5W3oE6wlfUhRjfmKzKZOrMuIoMqBkUA6rpEpq666_zOoD-Cxay62HjWWiueTiELKEtbe-Dq8_dqX5LZ27P2wWEiOXInv8pKKiHAxSQn" //
+			+ "qzn7FOH7KCh4u-cMemi-0itjP6KFbW_dpg0cca6RHyIPSCUejlyvfr0Spewf9D2q3j7iTK1QZL_nQck2TcdeVjE7_PpwX3hPDGtt9PFYFBL" //
+			+ "4od93JmcutaRXm0iXUNkBwwXf53Eiw8vTRwPkdJ-w6z6Bl4jjWMS5yDPPx--UscCooEgGJOpJivTFGwaa2f-vt4N4P0jfA2vZVIrz1II-T8" //
+			+ "O8DaVw7TtgsgfDm8DBXyoCESXY37ss58NVOWsqSgF8-TD4Rzpy2DCb9NC5tn_wLCt2vErg8veWVrNo99fXqOdDI0ymoEyqUB2sKqcDfIo0s" //
+			+ "mB_DFbcxmqFNG9tsS9O7Lg3L045eZlnM6u0G2hmPcOw5aHhZ3ZhL2s7S46-EJSvvYqLTlB2KTH-ww6JnftiEmKva6ABUuhmCD101XSFg0rh" //
+			+ "eYFFxtoIbFVXC7V6L3tv3IbSmI-jWDapJYgYjDapmBLaGRJyEU_oxILOPJEKvQnPdRORcNsYuKc3QZXLMKkTC1XtOzal6I5w_HcXPu8y19y" //
+			+ "ZpPP0NAl-QwFVI2s4Ch7UJYP-cbRee4sJzKzmLG7vM8_NrJLH_m-ecLqh2ahHpc4W-7bqbNJnbJ9E8Cvm4urGxTeyTlz3boGoBJXbtQx67T" //
+			+ "1bvj1Z-bFvOcSrX7UfDb-NMIaK09wxOyFO6wTD6B_VOEyChFuv0wWMLaYwPjAhMAkGBSsOAwIaBQAEFP9S30F1lPqFdDzVCTDtH1gXqITXB" //
+			+ "BSXiYwuLjMqaiwdT_Xbi0ue97zSVQIDAYag");
+
+	private P384KeyPair deviceKey;
+
+	@BeforeEach
+	public void setup() throws IOException {
+		this.deviceKey = P384KeyPair.load(new ByteArrayInputStream(devicePkcs12), "secret".toCharArray());
+	}
+
+	@Test
+	@DisplayName("decryptMasterkey(...)")
+	public void testDecrypt() {
+		String ephPk = "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEkcv3x-hkCnb8Kr8TNfaLpD4q64ZqPn4p1yuM8r2r16h6f6mG01kFBp2EoY575bCcmT54PxiDFkf3KKqHXFjZwBhdm6zMp22l37ZlmKyHG96vkB7Rh6qFyzEhSQ_nvl2G";
+		String ciphertext = "KQ48XS6ziW3tS7SMLR5sc2o_Y80OR4SS_htHpk8SHn4KrqI07EtDFFbNJ9AcNOazSu3TXrml--t_bEXprfnPqa3MlBvmPUVBcwUFJPDTR9Y";
+
+		Masterkey masterkey = MasterkeyHubAccess.decryptMasterkey(deviceKey, ciphertext, ephPk);
+
+		byte[] expectedKey = new byte[64];
+		Arrays.fill(expectedKey, 0, 32, (byte) 0x55);
+		Arrays.fill(expectedKey, 32, 64, (byte) 0x77);
+		Assertions.assertArrayEquals(expectedKey, masterkey.getEncoded());
+	}
+
+	@Test
+	@DisplayName("decryptMasterkey(...) with tampered ephemeral public key")
+	public void testDecryptWithInvalidEphemeralPublicKey() {
+		String ephPk = "mHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEkcv3x-hkCnb8Kr8TNfaLpD4q64ZqPn4p1yuM8r2r16h6f6mG01kFBp2EoY575bCcmT54PxiDFkf3KKqHXFjZwBhdm6zMp22l37ZlmKyHG96vkB7Rh6qFyzEhSQ_nvl2G";
+		String ciphertext = "KQ48XS6ziW3tS7SMLR5sc2o_Y80OR4SS_htHpk8SHn4KrqI07EtDFFbNJ9AcNOazSu3TXrml--t_bEXprfnPqa3MlBvmPUVBcwUFJPDTR9Y";
+
+		Assertions.assertThrows(MasterkeyLoadingFailedException.class, () -> {
+			MasterkeyHubAccess.decryptMasterkey(deviceKey, ciphertext, ephPk);
+		});
+	}
+
+	@Test
+	@DisplayName("decryptMasterkey(...) with tampered ciphertext")
+	public void testDecryptWithInvalidCiphertext() {
+		String ephPk = "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEkcv3x-hkCnb8Kr8TNfaLpD4q64ZqPn4p1yuM8r2r16h6f6mG01kFBp2EoY575bCcmT54PxiDFkf3KKqHXFjZwBhdm6zMp22l37ZlmKyHG96vkB7Rh6qFyzEhSQ_nvl2G";
+		String ciphertext = "kQ48XS6ziW3tS7SMLR5sc2o_Y80OR4SS_htHpk8SHn4KrqI07EtDFFbNJ9AcNOazSu3TXrml--t_bEXprfnPqa3MlBvmPUVBcwUFJPDTR9Y";
+
+		Assertions.assertThrows(MasterkeyLoadingFailedException.class, () -> {
+			MasterkeyHubAccess.decryptMasterkey(deviceKey, ciphertext, ephPk);
+		});
+	}
+
+	@Test
+	@DisplayName("decryptMasterkey(...) with invalid device key")
+	public void testDecryptWithInvalidDeviceKey() {
+		String ephPk = "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEkcv3x-hkCnb8Kr8TNfaLpD4q64ZqPn4p1yuM8r2r16h6f6mG01kFBp2EoY575bCcmT54PxiDFkf3KKqHXFjZwBhdm6zMp22l37ZlmKyHG96vkB7Rh6qFyzEhSQ_nvl2G";
+		String ciphertext = "KQ48XS6ziW3tS7SMLR5sc2o_Y80OR4SS_htHpk8SHn4KrqI07EtDFFbNJ9AcNOazSu3TXrml--t_bEXprfnPqa3MlBvmPUVBcwUFJPDTR9Y";
+		P384KeyPair wrongKey = P384KeyPair.generate();
+
+		Assertions.assertThrows(MasterkeyLoadingFailedException.class, () -> {
+			MasterkeyHubAccess.decryptMasterkey(wrongKey, ciphertext, ephPk);
+		});
+	}
+
+}

--- a/src/test/java/org/cryptomator/cryptolib/common/MasterkeyHubAccessTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/common/MasterkeyHubAccessTest.java
@@ -14,7 +14,7 @@ import java.util.Arrays;
 
 public class MasterkeyHubAccessTest {
 
-	private static final byte[] devicePkcs12 = BaseEncoding.base64Url().decode("MIIFhAIBAzCCBT0GCSqGSIb3DQEHAaCCBS" //
+	private static final byte[] DEVICE_PKCS12 = BaseEncoding.base64Url().decode("MIIFhAIBAzCCBT0GCSqGSIb3DQEHAaCCBS" //
 			+ "4EggUqMIIFJjCB6wYJKoZIhvcNAQcBoIHdBIHaMIHXMIHUBgsqhkiG9w0BDAoBAqCBiDCBhTApBgoqhkiG9w0BDAEDMBsEFGAM85ETk7ydc" //
 			+ "BZlJOEO4_4t7LcGAgMAw1AEWLu-1SdjZkqjOdwiQBOFYJkrtZimD0AHst3LxOmdVJZGJ2my4hgxQJH2sIcEnpNwQnrlBcI80xy4bozDxZ6W" //
 			+ "Asu-BymbjAqg86xpB6XBIQZj9NQ24OA1NuwxOjAVBgkqhkiG9w0BCRQxCB4GAGsAZQB5MCEGCSqGSIb3DQEJFTEUBBJUaW1lIDE2MjkzNjg" //
@@ -38,7 +38,7 @@ public class MasterkeyHubAccessTest {
 
 	@BeforeEach
 	public void setup() throws IOException {
-		this.deviceKey = P384KeyPair.load(new ByteArrayInputStream(devicePkcs12), "secret".toCharArray());
+		this.deviceKey = P384KeyPair.load(new ByteArrayInputStream(DEVICE_PKCS12), "secret".toCharArray());
 	}
 
 	@Test

--- a/src/test/java/org/cryptomator/cryptolib/ecies/ECIntegratedEncryptionSchemeTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/ecies/ECIntegratedEncryptionSchemeTest.java
@@ -52,7 +52,7 @@ public class ECIntegratedEncryptionSchemeTest {
 			Mockito.doAnswer(invocation -> invocation.getArgument(1)).when(ae).decrypt(Mockito.any(), Mockito.any());
 
 			// set up null KDF
-			Mockito.doReturn(derivedSecret).when(kdf).deriveKey(Mockito.eq(expectedSharedSecret), Mockito.eq(32));
+			Mockito.doReturn(derivedSecret).when(kdf).deriveKey(expectedSharedSecret, 32);
 		}
 
 		@Test
@@ -118,9 +118,10 @@ public class ECIntegratedEncryptionSchemeTest {
 		public void testEncryptWithInvalidKeyGen() throws NoSuchAlgorithmException {
 			KeyPairGenerator rsaKeyGen = KeyPairGenerator.getInstance("RSA");
 			byte[] cleartext = "hello world".getBytes(StandardCharsets.UTF_8);
+			ECPublicKey receiverPublicKey = (ECPublicKey) receiverKeyPair.getPublic();
 
 			Assertions.assertThrows(IllegalArgumentException.class, () -> {
-				ecies.encrypt(rsaKeyGen, (ECPublicKey) receiverKeyPair.getPublic(), cleartext);
+				ecies.encrypt(rsaKeyGen, receiverPublicKey, cleartext);
 			});
 		}
 

--- a/src/test/java/org/cryptomator/cryptolib/ecies/ECIntegratedEncryptionSchemeTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/ecies/ECIntegratedEncryptionSchemeTest.java
@@ -1,0 +1,160 @@
+package org.cryptomator.cryptolib.ecies;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.crypto.AEADBadTagException;
+import javax.crypto.KeyAgreement;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.util.Arrays;
+
+public class ECIntegratedEncryptionSchemeTest {
+
+	@Nested
+	@DisplayName("With null encryption scheme...")
+	public class WithIdentityCipher {
+
+		private AuthenticatedEncryption ae;
+		private KeyDerivationFunction kdf;
+		private ECIntegratedEncryptionScheme ecies;
+		private KeyPair ephemeral;
+		private KeyPair receiver;
+		private byte[] expectedSharedSecret;
+		private byte[] derivedSecret;
+
+		@BeforeEach
+		public void setup() throws AEADBadTagException, NoSuchAlgorithmException, InvalidKeyException {
+			this.ephemeral = KeyPairGenerator.getInstance("EC").generateKeyPair();
+			this.receiver = KeyPairGenerator.getInstance("EC").generateKeyPair();
+			KeyAgreement ecdh = KeyAgreement.getInstance("ECDH");
+			ecdh.init(ephemeral.getPrivate());
+			ecdh.doPhase(receiver.getPublic(), true);
+			this.expectedSharedSecret = ecdh.generateSecret();
+			this.ae = Mockito.mock(AuthenticatedEncryption.class);
+			this.kdf = Mockito.mock(KeyDerivationFunction.class);
+			this.ecies = new ECIntegratedEncryptionScheme(ae, kdf);
+			this.derivedSecret = new byte[32];
+			Arrays.fill(derivedSecret, (byte) 0xAA);
+
+			// set up null encryption
+			Mockito.doReturn(32).when(ae).requiredSecretBytes();
+			Mockito.doAnswer(invocation -> invocation.getArgument(1)).when(ae).encrypt(Mockito.any(), Mockito.any());
+			Mockito.doAnswer(invocation -> invocation.getArgument(1)).when(ae).decrypt(Mockito.any(), Mockito.any());
+
+			// set up null KDF
+			Mockito.doReturn(derivedSecret).when(kdf).deriveKey(Mockito.eq(expectedSharedSecret), Mockito.eq(32));
+		}
+
+		@Test
+		public void testEncryptWithInvalidKey() {
+			ECPrivateKey invalidSk = Mockito.mock(ECPrivateKey.class);
+			ECPublicKey validPk = (ECPublicKey) receiver.getPublic();
+			Mockito.doReturn("WRONG").when(invalidSk).getAlgorithm();
+
+			Assertions.assertThrows(IllegalArgumentException.class, () -> {
+				ecies.encrypt(invalidSk, validPk, new byte[42]);
+			});
+		}
+
+		@Test
+		public void testEncrypt() {
+			byte[] cleartext = "secret message".getBytes(StandardCharsets.UTF_8);
+
+			byte[] ciphertext = ecies.encrypt((ECPrivateKey) ephemeral.getPrivate(), (ECPublicKey) receiver.getPublic(), cleartext);
+
+			Assertions.assertArrayEquals(cleartext, ciphertext);
+			Mockito.verify(kdf).deriveKey(Mockito.any(), Mockito.eq(32));
+			Mockito.verify(ae).encrypt(derivedSecret, cleartext);
+		}
+
+		@Test
+		public void testDecrypt() throws AEADBadTagException {
+			byte[] ciphertext = "secret message".getBytes(StandardCharsets.UTF_8);
+
+			byte[] cleartext = ecies.decrypt((ECPrivateKey) receiver.getPrivate(), (ECPublicKey) ephemeral.getPublic(), ciphertext);
+
+			Assertions.assertArrayEquals(ciphertext, cleartext);
+			Mockito.verify(kdf).deriveKey(Mockito.any(), Mockito.eq(32));
+			Mockito.verify(ae).decrypt(derivedSecret, cleartext);
+		}
+
+	}
+
+	@Nested
+	@DisplayName("With Cryptomator Hub encryption scheme...")
+	public class WithHubScheme {
+
+		private ECIntegratedEncryptionScheme ecies = ECIntegratedEncryptionScheme.HUB;
+		private KeyPairGenerator keyGen;
+		private KeyPair receiverKeyPair;
+
+		@BeforeEach
+		public void setup() throws NoSuchAlgorithmException {
+			this.keyGen = KeyPairGenerator.getInstance("EC");
+			this.receiverKeyPair = keyGen.generateKeyPair();
+		}
+
+		@Test
+		@DisplayName("encrypt(...)")
+		public void testEncrypt() {
+			byte[] cleartext = "hello world".getBytes(StandardCharsets.UTF_8);
+			EncryptedMessage msg = ecies.encrypt(keyGen, (ECPublicKey) receiverKeyPair.getPublic(), cleartext);
+			Assertions.assertNotNull(msg.getCiphertext());
+			Assertions.assertNotNull(msg.getEphPublicKey());
+		}
+
+		@Test
+		@DisplayName("encrypt(...) with invalid keygen")
+		public void testEncryptWithInvalidKeyGen() throws NoSuchAlgorithmException {
+			KeyPairGenerator rsaKeyGen = KeyPairGenerator.getInstance("RSA");
+			byte[] cleartext = "hello world".getBytes(StandardCharsets.UTF_8);
+
+			Assertions.assertThrows(IllegalArgumentException.class, () -> {
+				ecies.encrypt(rsaKeyGen, (ECPublicKey) receiverKeyPair.getPublic(), cleartext);
+			});
+		}
+
+		@Nested
+		@DisplayName("With Cryptomator Hub encryption scheme...")
+		public class WithEncryptedMessage {
+
+			private byte[] expectedCleartext = "hello world".getBytes(StandardCharsets.UTF_8);
+			private EncryptedMessage encryptedMessage;
+
+			@BeforeEach
+			public void setup() throws NoSuchAlgorithmException {
+				byte[] cleartext = "hello world".getBytes(StandardCharsets.UTF_8);
+				this.encryptedMessage = ecies.encrypt(keyGen, (ECPublicKey) receiverKeyPair.getPublic(), cleartext);
+			}
+
+			@Test
+			@DisplayName("decrypt(...)")
+			public void testDecrypt() throws AEADBadTagException {
+				byte[] cleartext = ecies.decrypt((ECPrivateKey) receiverKeyPair.getPrivate(), encryptedMessage);
+				Assertions.assertArrayEquals(expectedCleartext, cleartext);
+			}
+
+			@Test
+			@DisplayName("decrypt(...) with invalid key")
+			public void testDecryptWithInvalidKey() {
+				ECPrivateKey wrongPrivateKey = (ECPrivateKey) keyGen.generateKeyPair().getPrivate();
+				Assertions.assertThrows(AEADBadTagException.class, () -> {
+					ecies.decrypt(wrongPrivateKey, encryptedMessage);
+				});
+			}
+
+		}
+
+	}
+
+}

--- a/src/test/java/org/cryptomator/cryptolib/ecies/GcmWithSecretNonceTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/ecies/GcmWithSecretNonceTest.java
@@ -1,0 +1,58 @@
+package org.cryptomator.cryptolib.ecies;
+
+import com.google.common.io.BaseEncoding;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.converter.ConvertWith;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import javax.crypto.AEADBadTagException;
+
+/**
+ * Test vectors from https://csrc.nist.rip/groups/ST/toolkit/BCM/documents/proposedmodes/gcm/gcm-spec.pdf
+ */
+public class GcmWithSecretNonceTest {
+
+	private final GcmWithSecretNonce ae = new GcmWithSecretNonce();
+
+	@Test
+	public void testRequiredSecretBytes() {
+		Assertions.assertEquals(44, ae.requiredSecretBytes());
+	}
+
+	@ParameterizedTest
+	@CsvSource(value = {
+			"0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000, , 530f8afbc74536b9a963b4f1c4cb738b", // test case 13
+			"feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308cafebabefacedbaddecaf888, d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255, 522dc1f099567d07f47f37a32a84427d643a8cdcbfe5c0c97598a2bd2555d1aa8cb08e48590dbb3da7b08b1056828838c5f61e6393ba7a0abcc9f662898015adb094dac5d93471bdec1a502270e3cc6c", // test case 15
+			"0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000, 00000000000000000000000000000000, cea7403d4d606b6e074ec5d3baf39d18d0d1c8a799996bf0265b98b5d48ab919", // test case 14
+	})
+	public void testEncrypt(@ConvertWith(HexConverter.class) byte[] secret, @ConvertWith(HexConverter.class) byte[] plaintext, @ConvertWith(HexConverter.class) byte[] expectedCiphertext) {
+		byte[] ciphertext = ae.encrypt(secret, plaintext);
+		Assertions.assertArrayEquals(expectedCiphertext, ciphertext);
+	}
+
+	@ParameterizedTest
+	@CsvSource(value = {
+			"0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000, , 530f8afbc74536b9a963b4f1c4cb738b", // test case 13
+			"0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000, 00000000000000000000000000000000, cea7403d4d606b6e074ec5d3baf39d18d0d1c8a799996bf0265b98b5d48ab919", // test case 14
+			"feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308cafebabefacedbaddecaf888, d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255, 522dc1f099567d07f47f37a32a84427d643a8cdcbfe5c0c97598a2bd2555d1aa8cb08e48590dbb3da7b08b1056828838c5f61e6393ba7a0abcc9f662898015adb094dac5d93471bdec1a502270e3cc6c", // test case 15
+	})
+	public void testDecrypt(@ConvertWith(HexConverter.class) byte[] secret, @ConvertWith(HexConverter.class) byte[] expectedPlaintext, @ConvertWith(HexConverter.class) byte[] ciphertext) throws AEADBadTagException {
+		byte[] plaintext = ae.decrypt(secret, ciphertext);
+		Assertions.assertArrayEquals(expectedPlaintext, plaintext);
+	}
+
+
+	@ParameterizedTest
+	@CsvSource(value = {
+			"0000000000000000000000000000000000000000000000000000000000000000000000000000000000000001, 530f8afbc74536b9a963b4f1c4cb738b",
+			"0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000, 530f8afbc74536b9a963b4f1c4cb738b",
+	})
+	public void testDecryptInvalid(@ConvertWith(HexConverter.class) byte[] secret, @ConvertWith(HexConverter.class) byte[] ciphertext) {
+		Assertions.assertThrows(AEADBadTagException.class, () -> {
+			ae.decrypt(secret, ciphertext);
+		});
+	}
+
+}

--- a/src/test/java/org/cryptomator/cryptolib/ecies/HexConverter.java
+++ b/src/test/java/org/cryptomator/cryptolib/ecies/HexConverter.java
@@ -1,0 +1,20 @@
+package org.cryptomator.cryptolib.ecies;
+
+import com.google.common.io.BaseEncoding;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.params.converter.ArgumentConversionException;
+import org.junit.jupiter.params.converter.ArgumentConverter;
+
+class HexConverter implements ArgumentConverter {
+
+	@Override
+	public byte[] convert(Object source, ParameterContext context) throws ArgumentConversionException {
+		if (source == null) {
+			return new byte[0];
+		} else if (source instanceof String) {
+			return BaseEncoding.base16().lowerCase().decode((String) source);
+		} else {
+			return null;
+		}
+	}
+}

--- a/src/test/java/org/cryptomator/cryptolib/ecies/KeyDerivationFunctionTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/ecies/KeyDerivationFunctionTest.java
@@ -1,0 +1,56 @@
+package org.cryptomator.cryptolib.ecies;
+
+import com.google.common.io.BaseEncoding;
+import org.cryptomator.cryptolib.ecies.KeyDerivationFunction;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.converter.ArgumentConversionException;
+import org.junit.jupiter.params.converter.ArgumentConverter;
+import org.junit.jupiter.params.converter.ConvertWith;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class KeyDerivationFunctionTest {
+
+	@DisplayName("ANSI-X9.63-KDF")
+	@ParameterizedTest
+	@CsvSource(value = {
+			"96c05619d56c328ab95fe84b18264b08725b85e33fd34f08, , 16, 443024c3dae66b95e6f5670601558f71",
+			"96f600b73ad6ac5629577eced51743dd2c24c21b1ac83ee4, , 16, b6295162a7804f5667ba9070f82fa522",
+			"22518b10e70f2a3f243810ae3254139efbee04aa57c7af7d, 75eef81aa3041e33b80971203d2c0c52, 128, c498af77161cc59f2962b9a713e2b215152d139766ce34a776df11866a69bf2e52a13d9c7c6fc878c50c5ea0bc7b00e0da2447cfd874f6cf92f30d0097111485500c90c3af8b487872d04685d14c8d1dc8d7fa08beb0ce0ababc11f0bd496269142d43525a78e5bc79a17f59676a5706dc54d54d4d1f0bd7e386128ec26afc21",
+			"7e335afa4b31d772c0635c7b0e06f26fcd781df947d2990a, d65a4812733f8cdbcdfb4b2f4c191d87, 128, c0bd9e38a8f9de14c2acd35b2f3410c6988cf02400543631e0d6a4c1d030365acbf398115e51aaddebdc9590664210f9aa9fed770d4c57edeafa0b8c14f93300865251218c262d63dadc47dfa0e0284826793985137e0a544ec80abf2fdf5ab90bdaea66204012efe34971dc431d625cd9a329b8217cc8fd0d9f02b13f2f6b0b",
+	})
+	// test vectors from https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/components/800-135testvectors/ansx963_2001.zip
+	public void testAnsiX963sha256(@ConvertWith(HexConverter.class) byte[] sharedSecret, @ConvertWith(HexConverter.class) byte[] sharedInfo, int outLen, @ConvertWith(HexConverter.class) byte[] expectedResult) {
+		byte[] result = KeyDerivationFunction.ansiX963sha256Kdf(sharedSecret, sharedInfo, outLen);
+		Assertions.assertArrayEquals(expectedResult, result);
+	}
+
+	@DisplayName("kdf.deriveKey()")
+	@Test
+	public void testDeriveKey() {
+		byte[] secret =  BaseEncoding.base16().lowerCase().decode("96c05619d56c328ab95fe84b18264b08725b85e33fd34f08");
+
+		byte[] result = KeyDerivationFunction.ANSI_X963_SHA256_KDF.deriveKey(secret, 16);
+
+		byte[] expected =  BaseEncoding.base16().lowerCase().decode("443024c3dae66b95e6f5670601558f71");
+		Assertions.assertArrayEquals(expected, result);
+	}
+
+	public static class HexConverter implements ArgumentConverter {
+
+		@Override
+		public byte[] convert(Object source, ParameterContext context) throws ArgumentConversionException {
+			if (source == null) {
+				return new byte[0];
+			} else if (source instanceof String) {
+				return BaseEncoding.base16().lowerCase().decode((String) source);
+			} else {
+				return null;
+			}
+		}
+	}
+
+}

--- a/src/test/java/org/cryptomator/cryptolib/ecies/KeyDerivationFunctionTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/ecies/KeyDerivationFunctionTest.java
@@ -1,14 +1,10 @@
 package org.cryptomator.cryptolib.ecies;
 
 import com.google.common.io.BaseEncoding;
-import org.cryptomator.cryptolib.ecies.KeyDerivationFunction;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.converter.ArgumentConversionException;
-import org.junit.jupiter.params.converter.ArgumentConverter;
 import org.junit.jupiter.params.converter.ConvertWith;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -37,20 +33,6 @@ public class KeyDerivationFunctionTest {
 
 		byte[] expected =  BaseEncoding.base16().lowerCase().decode("443024c3dae66b95e6f5670601558f71");
 		Assertions.assertArrayEquals(expected, result);
-	}
-
-	public static class HexConverter implements ArgumentConverter {
-
-		@Override
-		public byte[] convert(Object source, ParameterContext context) throws ArgumentConversionException {
-			if (source == null) {
-				return new byte[0];
-			} else if (source instanceof String) {
-				return BaseEncoding.base16().lowerCase().decode((String) source);
-			} else {
-				return null;
-			}
-		}
 	}
 
 }


### PR DESCRIPTION
Added MasterkeyHubAccess, which allows decryption of device-specific masterkeys used in Cryptomator Hub.

This facilitates ECIES with:
* P-384 curves
* ANSI X9.63 KDF with SHA-256 deriving a 256 + 96 bit secret
* AES-GCM with a 256 bit KEK and 96 bit nonce\* (derived by KDF)
* No separate MAC required, as a tag is included in GCM ciphertexts

\* The nonce is unique due to the nature of ECIES which facilitates ephemeral key pairs: The private key is immediately discarded during encryption, reuse is impossible when correctly implemented.