### PR TITLE
Replace `ThreadLocal`s with `ObjectPool`s

### DIFF
--- a/src/main/java/org/cryptomator/cryptolib/common/AesKeyWrap.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/AesKeyWrap.java
@@ -23,7 +23,7 @@ public class AesKeyWrap {
 	 */
 	public static byte[] wrap(DestroyableSecretKey kek, SecretKey key) {
 		try (DestroyableSecretKey kekCopy = kek.copy();
-			 CipherSupplier.ReusableCipher cipher = CipherSupplier.RFC3394_KEYWRAP.wrap(kekCopy)) {
+			 ObjectPool.Lease<Cipher> cipher = CipherSupplier.RFC3394_KEYWRAP.wrap(kekCopy)) {
 			return cipher.get().wrap(key);
 		} catch (InvalidKeyException | IllegalBlockSizeException e) {
 			throw new IllegalArgumentException("Unable to wrap key.", e);
@@ -44,7 +44,7 @@ public class AesKeyWrap {
 	// visible for testing
 	static DestroyableSecretKey unwrap(DestroyableSecretKey kek, byte[] wrappedKey, String wrappedKeyAlgorithm, int wrappedKeyType) throws InvalidKeyException {
 		try (DestroyableSecretKey kekCopy = kek.copy();
-			 CipherSupplier.ReusableCipher cipher = CipherSupplier.RFC3394_KEYWRAP.unwrap(kekCopy)) {
+			 ObjectPool.Lease<Cipher> cipher = CipherSupplier.RFC3394_KEYWRAP.unwrap(kekCopy)) {
 			return DestroyableSecretKey.from(cipher.get().unwrap(wrappedKey, wrappedKeyAlgorithm, wrappedKeyType));
 		} catch (NoSuchAlgorithmException e) {
 			throw new IllegalArgumentException("Invalid algorithm: " + wrappedKeyAlgorithm, e);

--- a/src/main/java/org/cryptomator/cryptolib/common/AesKeyWrap.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/AesKeyWrap.java
@@ -23,7 +23,7 @@ public class AesKeyWrap {
 	 */
 	public static byte[] wrap(DestroyableSecretKey kek, SecretKey key) {
 		try (DestroyableSecretKey kekCopy = kek.copy();
-			 ObjectPool.Lease<Cipher> cipher = CipherSupplier.RFC3394_KEYWRAP.wrap(kekCopy)) {
+			 ObjectPool.Lease<Cipher> cipher = CipherSupplier.RFC3394_KEYWRAP.keyWrapCipher(kekCopy)) {
 			return cipher.get().wrap(key);
 		} catch (InvalidKeyException | IllegalBlockSizeException e) {
 			throw new IllegalArgumentException("Unable to wrap key.", e);
@@ -44,7 +44,7 @@ public class AesKeyWrap {
 	// visible for testing
 	static DestroyableSecretKey unwrap(DestroyableSecretKey kek, byte[] wrappedKey, String wrappedKeyAlgorithm, int wrappedKeyType) throws InvalidKeyException {
 		try (DestroyableSecretKey kekCopy = kek.copy();
-			 ObjectPool.Lease<Cipher> cipher = CipherSupplier.RFC3394_KEYWRAP.unwrap(kekCopy)) {
+			 ObjectPool.Lease<Cipher> cipher = CipherSupplier.RFC3394_KEYWRAP.keyUnwrapCipher(kekCopy)) {
 			return DestroyableSecretKey.from(cipher.get().unwrap(wrappedKey, wrappedKeyAlgorithm, wrappedKeyType));
 		} catch (NoSuchAlgorithmException e) {
 			throw new IllegalArgumentException("Invalid algorithm: " + wrappedKeyAlgorithm, e);

--- a/src/main/java/org/cryptomator/cryptolib/common/AesKeyWrap.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/AesKeyWrap.java
@@ -22,9 +22,9 @@ public class AesKeyWrap {
 	 * @return Wrapped key
 	 */
 	public static byte[] wrap(DestroyableSecretKey kek, SecretKey key) {
-		try (DestroyableSecretKey kekCopy = kek.copy()) {
-			final Cipher cipher = CipherSupplier.RFC3394_KEYWRAP.forWrapping(kekCopy);
-			return cipher.wrap(key);
+		try (DestroyableSecretKey kekCopy = kek.copy();
+			 CipherSupplier.ReusableCipher cipher = CipherSupplier.RFC3394_KEYWRAP.wrap(kekCopy)) {
+			return cipher.get().wrap(key);
 		} catch (InvalidKeyException | IllegalBlockSizeException e) {
 			throw new IllegalArgumentException("Unable to wrap key.", e);
 		}
@@ -43,9 +43,9 @@ public class AesKeyWrap {
 
 	// visible for testing
 	static DestroyableSecretKey unwrap(DestroyableSecretKey kek, byte[] wrappedKey, String wrappedKeyAlgorithm, int wrappedKeyType) throws InvalidKeyException {
-		try (DestroyableSecretKey kekCopy = kek.copy()) {
-			final Cipher cipher = CipherSupplier.RFC3394_KEYWRAP.forUnwrapping(kekCopy);
-			return DestroyableSecretKey.from(cipher.unwrap(wrappedKey, wrappedKeyAlgorithm, wrappedKeyType));
+		try (DestroyableSecretKey kekCopy = kek.copy();
+			 CipherSupplier.ReusableCipher cipher = CipherSupplier.RFC3394_KEYWRAP.unwrap(kekCopy)) {
+			return DestroyableSecretKey.from(cipher.get().unwrap(wrappedKey, wrappedKeyAlgorithm, wrappedKeyType));
 		} catch (NoSuchAlgorithmException e) {
 			throw new IllegalArgumentException("Invalid algorithm: " + wrappedKeyAlgorithm, e);
 		}

--- a/src/main/java/org/cryptomator/cryptolib/common/CipherSupplier.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/CipherSupplier.java
@@ -41,12 +41,27 @@ public final class CipherSupplier {
 		}
 	}
 
+	/**
+	 * Leases a reusable cipher object initialized for encryption.
+	 *
+	 * @param key    Encryption key
+	 * @param params Params such as IV/Nonce
+	 * @return A ReusableCipher instance holding a refurbished Cipher
+	 */
 	public ReusableCipher encrypt(SecretKey key, AlgorithmParameterSpec params) {
 		ObjectPool<Cipher>.Lease lease = cipherPool.get();
 		initMode(lease.get(), Cipher.ENCRYPT_MODE, key, params);
 		return new ReusableCipher(lease);
 	}
 
+	/**
+	 * Creates a new Cipher object initialized for encryption.
+	 *
+	 * @param key    Encryption key
+	 * @param params Params such as IV/Nonce
+	 * @return New Cipher instance
+	 * @deprecated Use {@link #encrypt(SecretKey, AlgorithmParameterSpec)} instead.
+	 */
 	@Deprecated
 	public Cipher forEncryption(SecretKey key, AlgorithmParameterSpec params) {
 		final Cipher cipher = createCipher();
@@ -54,12 +69,27 @@ public final class CipherSupplier {
 		return cipher;
 	}
 
+	/**
+	 * Leases a reusable cipher object initialized for decryption.
+	 *
+	 * @param key    Decryption key
+	 * @param params Params such as IV/Nonce
+	 * @return A ReusableCipher instance holding a refurbished Cipher
+	 */
 	public ReusableCipher decrypt(SecretKey key, AlgorithmParameterSpec params) {
 		ObjectPool<Cipher>.Lease lease = cipherPool.get();
 		initMode(lease.get(), Cipher.DECRYPT_MODE, key, params);
 		return new ReusableCipher(lease);
 	}
 
+	/**
+	 * Creates a new Cipher object initialized for decryption.
+	 *
+	 * @param key    Encryption key
+	 * @param params Params such as IV/Nonce
+	 * @return New Cipher instance
+	 * @deprecated Use {@link #decrypt(SecretKey, AlgorithmParameterSpec)} instead.
+	 */
 	@Deprecated
 	public Cipher forDecryption(SecretKey key, AlgorithmParameterSpec params) {
 		final Cipher cipher = createCipher();
@@ -67,12 +97,25 @@ public final class CipherSupplier {
 		return cipher;
 	}
 
+	/**
+	 * Leases a reusable cipher object initialized for wrapping a key.
+	 *
+	 * @param kek Key encryption key
+	 * @return A ReusableCipher instance holding a refurbished Cipher
+	 */
 	public ReusableCipher wrap(SecretKey kek) {
 		ObjectPool<Cipher>.Lease lease = cipherPool.get();
 		initMode(lease.get(), Cipher.WRAP_MODE, kek, null);
 		return new ReusableCipher(lease);
 	}
 
+	/**
+	 * Creates a new Cipher object initialized for wrapping a key.
+	 *
+	 * @param kek Key encryption key
+	 * @return New Cipher instance
+	 * @deprecated Use {@link #wrap(SecretKey)} instead.
+	 */
 	@Deprecated
 	public Cipher forWrapping(SecretKey kek) {
 		final Cipher cipher = createCipher();
@@ -80,12 +123,25 @@ public final class CipherSupplier {
 		return cipher;
 	}
 
+	/**
+	 * Leases a reusable cipher object initialized for unwrapping a key.
+	 *
+	 * @param kek Key encryption key
+	 * @return A ReusableCipher instance holding a refurbished Cipher
+	 */
 	public ReusableCipher unwrap(SecretKey kek) {
 		ObjectPool<Cipher>.Lease lease = cipherPool.get();
 		initMode(lease.get(), Cipher.UNWRAP_MODE, kek, null);
 		return new ReusableCipher(lease);
 	}
 
+	/**
+	 * Creates a new Cipher object initialized for unwrapping a key.
+	 *
+	 * @param kek Key encryption key
+	 * @return New Cipher instance
+	 * @deprecated Use {@link #unwrap(SecretKey)} instead.
+	 */
 	@Deprecated
 	public Cipher forUnwrapping(SecretKey kek) {
 		final Cipher cipher = createCipher();

--- a/src/main/java/org/cryptomator/cryptolib/common/CipherSupplier.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/CipherSupplier.java
@@ -48,7 +48,7 @@ public final class CipherSupplier {
 	 * @param params Params such as IV/Nonce
 	 * @return A lease supplying a refurbished Cipher
 	 */
-	public ObjectPool.Lease<Cipher> encrypt(SecretKey key, AlgorithmParameterSpec params) {
+	public ObjectPool.Lease<Cipher> encryptionCipher(SecretKey key, AlgorithmParameterSpec params) {
 		ObjectPool.Lease<Cipher> lease = cipherPool.get();
 		initMode(lease.get(), Cipher.ENCRYPT_MODE, key, params);
 		return lease;
@@ -60,7 +60,7 @@ public final class CipherSupplier {
 	 * @param key    Encryption key
 	 * @param params Params such as IV/Nonce
 	 * @return New Cipher instance
-	 * @deprecated Use {@link #encrypt(SecretKey, AlgorithmParameterSpec)} instead.
+	 * @deprecated Use {@link #encryptionCipher(SecretKey, AlgorithmParameterSpec)} instead.
 	 */
 	@Deprecated
 	public Cipher forEncryption(SecretKey key, AlgorithmParameterSpec params) {
@@ -76,7 +76,7 @@ public final class CipherSupplier {
 	 * @param params Params such as IV/Nonce
 	 * @return A lease supplying a refurbished Cipher
 	 */
-	public ObjectPool.Lease<Cipher> decrypt(SecretKey key, AlgorithmParameterSpec params) {
+	public ObjectPool.Lease<Cipher> decryptionCipher(SecretKey key, AlgorithmParameterSpec params) {
 		ObjectPool.Lease<Cipher> lease = cipherPool.get();
 		initMode(lease.get(), Cipher.DECRYPT_MODE, key, params);
 		return lease;
@@ -88,7 +88,7 @@ public final class CipherSupplier {
 	 * @param key    Encryption key
 	 * @param params Params such as IV/Nonce
 	 * @return New Cipher instance
-	 * @deprecated Use {@link #decrypt(SecretKey, AlgorithmParameterSpec)} instead.
+	 * @deprecated Use {@link #decryptionCipher(SecretKey, AlgorithmParameterSpec)} instead.
 	 */
 	@Deprecated
 	public Cipher forDecryption(SecretKey key, AlgorithmParameterSpec params) {
@@ -103,7 +103,7 @@ public final class CipherSupplier {
 	 * @param kek Key encryption key
 	 * @return A lease supplying a refurbished Cipher
 	 */
-	public ObjectPool.Lease<Cipher> wrap(SecretKey kek) {
+	public ObjectPool.Lease<Cipher> keyWrapCipher(SecretKey kek) {
 		ObjectPool.Lease<Cipher> lease = cipherPool.get();
 		initMode(lease.get(), Cipher.WRAP_MODE, kek, null);
 		return lease;
@@ -114,7 +114,7 @@ public final class CipherSupplier {
 	 *
 	 * @param kek Key encryption key
 	 * @return New Cipher instance
-	 * @deprecated Use {@link #wrap(SecretKey)} instead.
+	 * @deprecated Use {@link #keyWrapCipher(SecretKey)} instead.
 	 */
 	@Deprecated
 	public Cipher forWrapping(SecretKey kek) {
@@ -129,7 +129,7 @@ public final class CipherSupplier {
 	 * @param kek Key encryption key
 	 * @return A lease supplying a refurbished Cipher
 	 */
-	public ObjectPool.Lease<Cipher> unwrap(SecretKey kek) {
+	public ObjectPool.Lease<Cipher> keyUnwrapCipher(SecretKey kek) {
 		ObjectPool.Lease<Cipher> lease = cipherPool.get();
 		initMode(lease.get(), Cipher.UNWRAP_MODE, kek, null);
 		return lease;
@@ -140,7 +140,7 @@ public final class CipherSupplier {
 	 *
 	 * @param kek Key encryption key
 	 * @return New Cipher instance
-	 * @deprecated Use {@link #unwrap(SecretKey)} instead.
+	 * @deprecated Use {@link #keyUnwrapCipher(SecretKey)} instead.
 	 */
 	@Deprecated
 	public Cipher forUnwrapping(SecretKey kek) {

--- a/src/main/java/org/cryptomator/cryptolib/common/CipherSupplier.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/CipherSupplier.java
@@ -15,7 +15,6 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.AlgorithmParameterSpec;
-import java.util.function.Function;
 
 public final class CipherSupplier {
 
@@ -24,51 +23,101 @@ public final class CipherSupplier {
 	public static final CipherSupplier RFC3394_KEYWRAP = new CipherSupplier("AESWrap");
 
 	private final String cipherAlgorithm;
-	private final ThreadLocal<Cipher> threadLocal;
+	private final ObjectPool<Cipher> cipherPool;
 
 	public CipherSupplier(String cipherAlgorithm) {
 		this.cipherAlgorithm = cipherAlgorithm;
-		this.threadLocal = new Provider();
-		this.threadLocal.get(); // eagerly initialize to provoke exceptions
-	}
-
-	private class Provider extends ThreadLocal<Cipher> {
-		@Override
-		protected Cipher initialValue() {
-			try {
-				return Cipher.getInstance(cipherAlgorithm);
-			} catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
-				throw new IllegalArgumentException("Invalid cipher algorithm or padding.", e);
-			}
+		this.cipherPool = new ObjectPool<>(this::createCipher);
+		try (ObjectPool<Cipher>.Lease lease = cipherPool.get()) {
+			lease.get(); // eagerly initialize to provoke exceptions
 		}
 	}
 
+	private Cipher createCipher() {
+		try {
+			return Cipher.getInstance(cipherAlgorithm);
+		} catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+			throw new IllegalArgumentException("Invalid cipher algorithm or padding.", e);
+		}
+	}
+
+	public ReusableCipher encrypt(SecretKey key, AlgorithmParameterSpec params) {
+		ObjectPool<Cipher>.Lease lease = cipherPool.get();
+		initMode(lease.get(), Cipher.ENCRYPT_MODE, key, params);
+		return new ReusableCipher(lease);
+	}
+
+	@Deprecated
 	public Cipher forEncryption(SecretKey key, AlgorithmParameterSpec params) {
-		return forMode(Cipher.ENCRYPT_MODE, key, params);
+		final Cipher cipher = createCipher();
+		initMode(cipher, Cipher.ENCRYPT_MODE, key, params);
+		return cipher;
 	}
 
+	public ReusableCipher decrypt(SecretKey key, AlgorithmParameterSpec params) {
+		ObjectPool<Cipher>.Lease lease = cipherPool.get();
+		initMode(lease.get(), Cipher.DECRYPT_MODE, key, params);
+		return new ReusableCipher(lease);
+	}
+
+	@Deprecated
 	public Cipher forDecryption(SecretKey key, AlgorithmParameterSpec params) {
-		return forMode(Cipher.DECRYPT_MODE, key, params);
+		final Cipher cipher = createCipher();
+		initMode(cipher, Cipher.DECRYPT_MODE, key, params);
+		return cipher;
 	}
 
+	public ReusableCipher wrap(SecretKey kek) {
+		ObjectPool<Cipher>.Lease lease = cipherPool.get();
+		initMode(lease.get(), Cipher.WRAP_MODE, kek, null);
+		return new ReusableCipher(lease);
+	}
+
+	@Deprecated
 	public Cipher forWrapping(SecretKey kek) {
-		return forMode(Cipher.WRAP_MODE, kek, null);
+		final Cipher cipher = createCipher();
+		initMode(cipher, Cipher.WRAP_MODE, kek, null);
+		return cipher;
 	}
 
+	public ReusableCipher unwrap(SecretKey kek) {
+		ObjectPool<Cipher>.Lease lease = cipherPool.get();
+		initMode(lease.get(), Cipher.UNWRAP_MODE, kek, null);
+		return new ReusableCipher(lease);
+	}
+
+	@Deprecated
 	public Cipher forUnwrapping(SecretKey kek) {
-		return forMode(Cipher.UNWRAP_MODE, kek, null);
+		final Cipher cipher = createCipher();
+		initMode(cipher, Cipher.UNWRAP_MODE, kek, null);
+		return cipher;
 	}
 
-	// visible for testing
-	Cipher forMode(int ciphermode, SecretKey key, AlgorithmParameterSpec params) {
-		final Cipher cipher = threadLocal.get();
+	private void initMode(Cipher cipher, int ciphermode, SecretKey key, AlgorithmParameterSpec params) {
 		try {
 			cipher.init(ciphermode, key, params);
-			return cipher;
 		} catch (InvalidKeyException e) {
 			throw new IllegalArgumentException("Invalid key.", e);
 		} catch (InvalidAlgorithmParameterException e) {
 			throw new IllegalArgumentException("Algorithm parameter not appropriate for " + cipher.getAlgorithm() + ".", e);
+		}
+	}
+
+	public static class ReusableCipher implements AutoCloseable {
+
+		private final ObjectPool<Cipher>.Lease lease;
+
+		private ReusableCipher(ObjectPool<Cipher>.Lease lease) {
+			this.lease = lease;
+		}
+
+		public Cipher get() {
+			return lease.get();
+		}
+
+		@Override
+		public void close() {
+			lease.close();
 		}
 	}
 }

--- a/src/main/java/org/cryptomator/cryptolib/common/MacSupplier.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/MacSupplier.java
@@ -8,42 +8,71 @@
  *******************************************************************************/
 package org.cryptomator.cryptolib.common;
 
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-
+import javax.crypto.Cipher;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 
 public final class MacSupplier {
 
 	public static final MacSupplier HMAC_SHA256 = new MacSupplier("HmacSHA256");
 
 	private final String macAlgorithm;
-	private final ThreadLocal<Mac> threadLocal;
+	private final ObjectPool<Mac> macPool;
 
 	public MacSupplier(String macAlgorithm) {
 		this.macAlgorithm = macAlgorithm;
-		this.threadLocal = new Provider();
-	}
-
-	private class Provider extends ThreadLocal<Mac> {
-		@Override
-		protected Mac initialValue() {
-			try {
-				return Mac.getInstance(macAlgorithm);
-			} catch (NoSuchAlgorithmException e) {
-				throw new IllegalArgumentException("Invalid MAC algorithm.", e);
-			}
+		this.macPool = new ObjectPool<>(this::createMac);
+		try (ObjectPool<Mac>.Lease lease = macPool.get()) {
+			lease.get(); // eagerly initialize to provoke exceptions
 		}
 	}
 
-	public Mac withKey(SecretKey key) {
+	private Mac createMac() {
 		try {
-			final Mac mac = threadLocal.get();
+			return Mac.getInstance(macAlgorithm);
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalArgumentException("Invalid MAC algorithm.", e);
+		}
+	}
+
+	public ReusableMac keyed(SecretKey key) {
+		ObjectPool<Mac>.Lease lease = macPool.get();
+		init(lease.get(), key);
+		return new ReusableMac(lease);
+	}
+
+	@Deprecated
+	public Mac withKey(SecretKey key) {
+		final Mac mac = createMac();
+		init(mac, key);
+		return mac;
+	}
+
+	private void init(Mac mac, SecretKey key) {
+		try {
 			mac.init(key);
-			return mac;
 		} catch (InvalidKeyException e) {
 			throw new IllegalArgumentException("Invalid key.", e);
+		}
+	}
+
+	public static class ReusableMac implements AutoCloseable {
+
+		private final ObjectPool<Mac>.Lease lease;
+
+		private ReusableMac(ObjectPool<Mac>.Lease lease) {
+			this.lease = lease;
+		}
+
+		public Mac get() {
+			return lease.get();
+		}
+
+		@Override
+		public void close() {
+			lease.close();
 		}
 	}
 

--- a/src/main/java/org/cryptomator/cryptolib/common/MacSupplier.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/MacSupplier.java
@@ -37,12 +37,25 @@ public final class MacSupplier {
 		}
 	}
 
+	/**
+	 * Leases a reusable MAC object initialized with the given key.
+	 *
+	 * @param key Key to use in keyed MAC
+	 * @return A ReusableMac instance holding a refurbished MAC
+	 */
 	public ReusableMac keyed(SecretKey key) {
 		ObjectPool<Mac>.Lease lease = macPool.get();
 		init(lease.get(), key);
 		return new ReusableMac(lease);
 	}
 
+	/**
+	 * Creates a new MAC
+	 *
+	 * @param key Key to use in keyed MAC
+	 * @return New Mac instance
+	 * @deprecated Use {@link #keyed(SecretKey)} instead
+	 */
 	@Deprecated
 	public Mac withKey(SecretKey key) {
 		final Mac mac = createMac();

--- a/src/main/java/org/cryptomator/cryptolib/common/MacSupplier.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/MacSupplier.java
@@ -8,7 +8,6 @@
  *******************************************************************************/
 package org.cryptomator.cryptolib.common;
 
-import javax.crypto.Cipher;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import java.security.InvalidKeyException;

--- a/src/main/java/org/cryptomator/cryptolib/common/MasterkeyFileAccess.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/MasterkeyFileAccess.java
@@ -5,6 +5,7 @@ import org.cryptomator.cryptolib.api.InvalidPassphraseException;
 import org.cryptomator.cryptolib.api.Masterkey;
 import org.cryptomator.cryptolib.api.MasterkeyLoadingFailedException;
 
+import javax.crypto.Mac;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -193,7 +194,7 @@ public class MasterkeyFileAccess {
 		csprng.nextBytes(salt);
 		try (DestroyableSecretKey kek = scrypt(passphrase, salt, pepper, scryptCostParam, DEFAULT_SCRYPT_BLOCK_SIZE);
 			 DestroyableSecretKey macKey = masterkey.getMacKey();
-			 MacSupplier.ReusableMac mac = MacSupplier.HMAC_SHA256.keyed(macKey)) {
+			 ObjectPool.Lease<Mac> mac = MacSupplier.HMAC_SHA256.keyed(macKey)) {
 			final byte[] versionMac = mac.get().doFinal(ByteBuffer.allocate(Integer.SIZE / Byte.SIZE).putInt(vaultVersion).array());
 			MasterkeyFile result = new MasterkeyFile();
 			result.version = vaultVersion;

--- a/src/main/java/org/cryptomator/cryptolib/common/MasterkeyFileAccess.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/MasterkeyFileAccess.java
@@ -192,9 +192,10 @@ public class MasterkeyFileAccess {
 
 		final byte[] salt = new byte[DEFAULT_SCRYPT_SALT_LENGTH];
 		csprng.nextBytes(salt);
-		try (DestroyableSecretKey kek = scrypt(passphrase, salt, pepper, scryptCostParam, DEFAULT_SCRYPT_BLOCK_SIZE)) {
-			final Mac mac = MacSupplier.HMAC_SHA256.withKey(masterkey.getMacKey());
-			final byte[] versionMac = mac.doFinal(ByteBuffer.allocate(Integer.SIZE / Byte.SIZE).putInt(vaultVersion).array());
+		try (DestroyableSecretKey kek = scrypt(passphrase, salt, pepper, scryptCostParam, DEFAULT_SCRYPT_BLOCK_SIZE);
+			 DestroyableSecretKey macKey = masterkey.getMacKey();
+			 MacSupplier.ReusableMac mac = MacSupplier.HMAC_SHA256.keyed(macKey)) {
+			final byte[] versionMac = mac.get().doFinal(ByteBuffer.allocate(Integer.SIZE / Byte.SIZE).putInt(vaultVersion).array());
 			MasterkeyFile result = new MasterkeyFile();
 			result.version = vaultVersion;
 			result.versionMac = versionMac;

--- a/src/main/java/org/cryptomator/cryptolib/common/MasterkeyFileAccess.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/MasterkeyFileAccess.java
@@ -5,7 +5,6 @@ import org.cryptomator.cryptolib.api.InvalidPassphraseException;
 import org.cryptomator.cryptolib.api.Masterkey;
 import org.cryptomator.cryptolib.api.MasterkeyLoadingFailedException;
 
-import javax.crypto.Mac;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/src/main/java/org/cryptomator/cryptolib/common/MessageDigestSupplier.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/MessageDigestSupplier.java
@@ -35,12 +35,23 @@ public final class MessageDigestSupplier {
 		}
 	}
 
+	/**
+	 * Leases a reusable MessageDigest.
+	 *
+	 * @return A ReusableMessageDigest instance holding a refurbished MessageDigest
+	 */
 	public ReusableMessageDigest instance() {
 		ObjectPool<MessageDigest>.Lease lease = mdPool.get();
 		lease.get().reset();
 		return new ReusableMessageDigest(lease);
 	}
 
+	/**
+	 * Creates a new MessageDigest.
+	 *
+	 * @deprecated Use {@link #instance()}
+	 * @return New MessageDigest instance
+	 */
 	@Deprecated
 	public MessageDigest get() {
 		final MessageDigest result = createMessageDigest();

--- a/src/main/java/org/cryptomator/cryptolib/common/MessageDigestSupplier.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/MessageDigestSupplier.java
@@ -17,28 +17,52 @@ public final class MessageDigestSupplier {
 	public static final MessageDigestSupplier SHA256 = new MessageDigestSupplier("SHA-256");
 
 	private final String digestAlgorithm;
-	private final ThreadLocal<MessageDigest> threadLocal;
+	private final ObjectPool<MessageDigest> mdPool;
 
 	public MessageDigestSupplier(String digestAlgorithm) {
 		this.digestAlgorithm = digestAlgorithm;
-		this.threadLocal = new Provider();
-	}
-
-	private class Provider extends ThreadLocal<MessageDigest> {
-		@Override
-		protected MessageDigest initialValue() {
-			try {
-				return MessageDigest.getInstance(digestAlgorithm);
-			} catch (NoSuchAlgorithmException e) {
-				throw new IllegalArgumentException("Invalid digest algorithm.", e);
-			}
+		this.mdPool = new ObjectPool<>(this::createMessageDigest);
+		try (ObjectPool<MessageDigest>.Lease lease = mdPool.get()) {
+			lease.get(); // eagerly initialize to provoke exceptions
 		}
 	}
 
+	private MessageDigest createMessageDigest() {
+		try {
+			return MessageDigest.getInstance(digestAlgorithm);
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalArgumentException("Invalid digest algorithm.", e);
+		}
+	}
+
+	public ReusableMessageDigest instance() {
+		ObjectPool<MessageDigest>.Lease lease = mdPool.get();
+		lease.get().reset();
+		return new ReusableMessageDigest(lease);
+	}
+
+	@Deprecated
 	public MessageDigest get() {
-		final MessageDigest result = threadLocal.get();
+		final MessageDigest result = createMessageDigest();
 		result.reset();
 		return result;
 	}
 
+	public static class ReusableMessageDigest implements AutoCloseable {
+
+		private final ObjectPool<MessageDigest>.Lease lease;
+
+		private ReusableMessageDigest(ObjectPool<MessageDigest>.Lease lease) {
+			this.lease = lease;
+		}
+
+		public MessageDigest get() {
+			return lease.get();
+		}
+
+		@Override
+		public void close() {
+			lease.close();
+		}
+	}
 }

--- a/src/main/java/org/cryptomator/cryptolib/common/ObjectPool.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/ObjectPool.java
@@ -1,0 +1,48 @@
+package org.cryptomator.cryptolib.common;
+
+import java.lang.ref.WeakReference;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Supplier;
+
+public class ObjectPool<T> {
+
+	private final Queue<WeakReference<T>> pool;
+	private final Supplier<T> factory;
+
+	public ObjectPool(Supplier<T> factory) {
+		this.pool = new ConcurrentLinkedQueue<>();
+		this.factory = factory;
+	}
+
+	public Lease get() {
+		WeakReference<T> ref;
+		while ((ref = pool.poll()) != null) {
+			T cached = ref.get();
+			if (cached != null) {
+				return new Lease(cached);
+			}
+		}
+		return new Lease(factory.get());
+	}
+
+	public class Lease implements AutoCloseable {
+
+		private T obj;
+
+		public Lease(T obj) {
+			this.obj = obj;
+		}
+
+		public T get() {
+			return obj;
+		}
+
+		@Override
+		public void close() {
+			pool.offer(new WeakReference<>(obj));
+			obj = null;
+		}
+	}
+
+}

--- a/src/main/java/org/cryptomator/cryptolib/common/ObjectPool.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/ObjectPool.java
@@ -5,6 +5,20 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Supplier;
 
+/**
+ * A simple object pool for resources that are expensive to create but are needed frequently.
+ * <p>
+ * Example Usage:
+ * <pre>{@code
+ *     Supplier<Foo> fooFactory = () -> new Foo();
+ *     ObjectPool<Foo> fooPool = new ObjectPool(fooFactory);
+ *     try (ObjectPool.Lease<Foo> lease = fooPool.get()) { // attempts to get a pooled Foo or invokes factory
+ *         lease.get().foo(); // exclusively use Foo instance
+ *     } // releases instance back to the pool when done
+ * }</pre>
+ *
+ * @param <T> Type of the pooled objects
+ */
 public class ObjectPool<T> {
 
 	private final Queue<WeakReference<T>> returnedInstances;

--- a/src/main/java/org/cryptomator/cryptolib/common/Scrypt.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/Scrypt.java
@@ -72,21 +72,21 @@ public class Scrypt {
 			throw new IllegalArgumentException("Parameter r is too large");
 		}
 
-		try (DestroyableSecretKey key = new DestroyableSecretKey(passphrase, "HmacSHA256")) {
-			Mac mac = MacSupplier.HMAC_SHA256.withKey(key);
+		try (DestroyableSecretKey key = new DestroyableSecretKey(passphrase, "HmacSHA256");
+			 MacSupplier.ReusableMac mac = MacSupplier.HMAC_SHA256.keyed(key)) {
 
 			byte[] DK = new byte[keyLengthInBytes];
 			byte[] B = new byte[128 * blockSize * P];
 			byte[] XY = new byte[256 * blockSize];
 			byte[] V = new byte[128 * blockSize * costParam];
 
-			pbkdf2(mac, salt, 1, B, P * 128 * blockSize);
+			pbkdf2(mac.get(), salt, 1, B, P * 128 * blockSize);
 
 			for (int i = 0; i < P; i++) {
 				smix(B, i * 128 * blockSize, blockSize, costParam, V, XY);
 			}
 
-			pbkdf2(mac, B, 1, DK, keyLengthInBytes);
+			pbkdf2(mac.get(), B, 1, DK, keyLengthInBytes);
 
 			return DK;
 		}

--- a/src/main/java/org/cryptomator/cryptolib/common/Scrypt.java
+++ b/src/main/java/org/cryptomator/cryptolib/common/Scrypt.java
@@ -73,7 +73,7 @@ public class Scrypt {
 		}
 
 		try (DestroyableSecretKey key = new DestroyableSecretKey(passphrase, "HmacSHA256");
-			 MacSupplier.ReusableMac mac = MacSupplier.HMAC_SHA256.keyed(key)) {
+			 ObjectPool.Lease<Mac> mac = MacSupplier.HMAC_SHA256.keyed(key)) {
 
 			byte[] DK = new byte[keyLengthInBytes];
 			byte[] B = new byte[128 * blockSize * P];

--- a/src/main/java/org/cryptomator/cryptolib/ecies/GcmWithSecretNonce.java
+++ b/src/main/java/org/cryptomator/cryptolib/ecies/GcmWithSecretNonce.java
@@ -27,7 +27,7 @@ class GcmWithSecretNonce implements AuthenticatedEncryption {
 	public byte[] encrypt(byte[] secret, byte[] plaintext) {
 		try (DestroyableSecretKey key = new DestroyableSecretKey(secret, 0, GCM_KEY_SIZE, "AES")) {
 			byte[] nonce = Arrays.copyOfRange(secret, GCM_KEY_SIZE, GCM_KEY_SIZE + GCM_NONCE_SIZE);
-			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_GCM.encrypt(key, new GCMParameterSpec(GCM_TAG_SIZE * Byte.SIZE, nonce))) {
+			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_GCM.encryptionCipher(key, new GCMParameterSpec(GCM_TAG_SIZE * Byte.SIZE, nonce))) {
 				return cipher.get().doFinal(plaintext);
 			}
 		} catch (IllegalBlockSizeException | BadPaddingException e) {
@@ -39,7 +39,7 @@ class GcmWithSecretNonce implements AuthenticatedEncryption {
 	public byte[] decrypt(byte[] secret, byte[] ciphertext) throws AEADBadTagException {
 		try (DestroyableSecretKey key = new DestroyableSecretKey(secret, 0, GCM_KEY_SIZE, "AES")) {
 			byte[] nonce = Arrays.copyOfRange(secret, GCM_KEY_SIZE, GCM_KEY_SIZE + GCM_NONCE_SIZE);
-			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_GCM.decrypt(key, new GCMParameterSpec(GCM_TAG_SIZE * Byte.SIZE, nonce))) {
+			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_GCM.decryptionCipher(key, new GCMParameterSpec(GCM_TAG_SIZE * Byte.SIZE, nonce))) {
 				return cipher.get().doFinal(ciphertext);
 			}
 		} catch (IllegalBlockSizeException | BadPaddingException e) {

--- a/src/main/java/org/cryptomator/cryptolib/ecies/GcmWithSecretNonce.java
+++ b/src/main/java/org/cryptomator/cryptolib/ecies/GcmWithSecretNonce.java
@@ -6,10 +6,8 @@ import org.cryptomator.cryptolib.common.DestroyableSecretKey;
 
 import javax.crypto.AEADBadTagException;
 import javax.crypto.BadPaddingException;
-import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.spec.GCMParameterSpec;
-import javax.crypto.spec.IvParameterSpec;
 import java.util.Arrays;
 
 class GcmWithSecretNonce implements AuthenticatedEncryption {

--- a/src/main/java/org/cryptomator/cryptolib/ecies/KeyDerivationFunction.java
+++ b/src/main/java/org/cryptomator/cryptolib/ecies/KeyDerivationFunction.java
@@ -1,11 +1,13 @@
 package org.cryptomator.cryptolib.ecies;
 
 import org.cryptomator.cryptolib.common.MessageDigestSupplier;
+import org.cryptomator.cryptolib.common.ObjectPool;
 
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.security.DigestException;
+import java.security.MessageDigest;
 import java.util.Arrays;
 
 @FunctionalInterface
@@ -42,7 +44,7 @@ public interface KeyDerivationFunction {
 		assert ByteOrder.BIG_ENDIAN.equals(counter.order());
 		int n = (keyDataLen + hashLen - 1) / hashLen;
 		byte[] buffer = new byte[n * hashLen];
-		try (MessageDigestSupplier.ReusableMessageDigest sha256 = MessageDigestSupplier.SHA256.instance()) {
+		try (ObjectPool.Lease<MessageDigest> sha256 = MessageDigestSupplier.SHA256.instance()) {
 			for (int i = 0; i < n; i++) {
 				sha256.get().update(sharedSecret);
 				counter.clear();

--- a/src/main/java/org/cryptomator/cryptolib/ecies/KeyDerivationFunction.java
+++ b/src/main/java/org/cryptomator/cryptolib/ecies/KeyDerivationFunction.java
@@ -6,7 +6,6 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.security.DigestException;
-import java.security.MessageDigest;
 import java.util.Arrays;
 
 @FunctionalInterface
@@ -32,8 +31,8 @@ public interface KeyDerivationFunction {
 	 * @return key data
 	 */
 	static byte[] ansiX963sha256Kdf(byte[] sharedSecret, byte[] sharedInfo, int keyDataLen) {
-		MessageDigest digest = MessageDigestSupplier.SHA256.get(); // max input length is 2^64 - 1, see https://doi.org/10.6028/NIST.SP.800-56Cr2, Table 1
-		int hashLen = digest.getDigestLength();
+		// max input length is 2^64 - 1, see https://doi.org/10.6028/NIST.SP.800-56Cr2, Table 1
+		int hashLen = 32; // fixed digest length for SHA-256 in bytes
 
 		// These two checks must be performed according to spec. However with 32 bit integers, we can't exceed any limits anyway:
 		assert BigInteger.valueOf(4L + sharedSecret.length + sharedInfo.length).compareTo(BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE)) < 0 : "input larger than hashmaxlen";
@@ -43,15 +42,15 @@ public interface KeyDerivationFunction {
 		assert ByteOrder.BIG_ENDIAN.equals(counter.order());
 		int n = (keyDataLen + hashLen - 1) / hashLen;
 		byte[] buffer = new byte[n * hashLen];
-		try {
+		try (MessageDigestSupplier.ReusableMessageDigest sha256 = MessageDigestSupplier.SHA256.instance()) {
 			for (int i = 0; i < n; i++) {
-				digest.update(sharedSecret);
+				sha256.get().update(sharedSecret);
 				counter.clear();
 				counter.putInt(i + 1);
 				counter.flip();
-				digest.update(counter);
-				digest.update(sharedInfo);
-				digest.digest(buffer, i * hashLen, hashLen);
+				sha256.get().update(counter);
+				sha256.get().update(sharedInfo);
+				sha256.get().digest(buffer, i * hashLen, hashLen);
 			}
 			return Arrays.copyOf(buffer, keyDataLen);
 		} catch (DigestException e) {

--- a/src/main/java/org/cryptomator/cryptolib/v1/FileContentCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v1/FileContentCryptorImpl.java
@@ -112,7 +112,7 @@ class FileContentCryptorImpl implements FileContentCryptor {
 
 			// payload:
 			int bytesEncrypted;
-			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_CTR.encrypt(fk, new IvParameterSpec(nonce))) {
+			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_CTR.encryptionCipher(fk, new IvParameterSpec(nonce))) {
 				assert ciphertextChunk.remaining() >= cipher.get().getOutputSize(cleartextChunk.remaining()) + MAC_SIZE;
 				bytesEncrypted = cipher.get().doFinal(cleartextChunk, ciphertextChunk);
 			}
@@ -146,7 +146,7 @@ class FileContentCryptorImpl implements FileContentCryptor {
 			payloadBuf.position(NONCE_SIZE).limit(ciphertextChunk.limit() - MAC_SIZE);
 
 			// payload:
-			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_CTR.decrypt(fk, new IvParameterSpec(nonce))) {
+			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_CTR.decryptionCipher(fk, new IvParameterSpec(nonce))) {
 				assert cleartextChunk.remaining() >= cipher.get().getOutputSize(payloadBuf.remaining());
 				cipher.get().doFinal(payloadBuf, cleartextChunk);
 			}

--- a/src/main/java/org/cryptomator/cryptolib/v1/FileContentCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v1/FileContentCryptorImpl.java
@@ -145,7 +145,7 @@ class FileContentCryptorImpl implements FileContentCryptor {
 			payloadBuf.position(NONCE_SIZE).limit(ciphertextChunk.limit() - MAC_SIZE);
 
 			// payload:
-			try (CipherSupplier.ReusableCipher cipher = CipherSupplier.AES_CTR.encrypt(fk, new IvParameterSpec(nonce))) {
+			try (CipherSupplier.ReusableCipher cipher = CipherSupplier.AES_CTR.decrypt(fk, new IvParameterSpec(nonce))) {
 				assert cleartextChunk.remaining() >= cipher.get().getOutputSize(payloadBuf.remaining());
 				cipher.get().doFinal(payloadBuf, cleartextChunk);
 			}

--- a/src/main/java/org/cryptomator/cryptolib/v1/FileContentCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v1/FileContentCryptorImpl.java
@@ -184,14 +184,14 @@ class FileContentCryptorImpl implements FileContentCryptor {
 	}
 
 	private byte[] calcChunkMac(byte[] headerNonce, long chunkNumber, byte[] chunkNonce, ByteBuffer ciphertext) {
-		try (DestroyableSecretKey mk = masterkey.getMacKey()) {
+		try (DestroyableSecretKey mk = masterkey.getMacKey();
+			 MacSupplier.ReusableMac mac = MacSupplier.HMAC_SHA256.keyed(mk)) {
 			final byte[] chunkNumberBigEndian = ByteBuffer.allocate(Long.SIZE / Byte.SIZE).order(ByteOrder.BIG_ENDIAN).putLong(chunkNumber).array();
-			final Mac mac = MacSupplier.HMAC_SHA256.withKey(mk);
-			mac.update(headerNonce);
-			mac.update(chunkNumberBigEndian);
-			mac.update(chunkNonce);
-			mac.update(ciphertext);
-			return mac.doFinal();
+			mac.get().update(headerNonce);
+			mac.get().update(chunkNumberBigEndian);
+			mac.get().update(chunkNonce);
+			mac.get().update(ciphertext);
+			return mac.get().doFinal();
 		}
 	}
 

--- a/src/main/java/org/cryptomator/cryptolib/v1/FileContentCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v1/FileContentCryptorImpl.java
@@ -17,9 +17,7 @@ import org.cryptomator.cryptolib.common.DestroyableSecretKey;
 import org.cryptomator.cryptolib.common.MacSupplier;
 
 import javax.crypto.BadPaddingException;
-import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.Mac;
 import javax.crypto.ShortBufferException;
 import javax.crypto.spec.IvParameterSpec;
 import java.nio.ByteBuffer;

--- a/src/main/java/org/cryptomator/cryptolib/v1/FileHeaderCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v1/FileHeaderCryptorImpl.java
@@ -18,7 +18,6 @@ import org.cryptomator.cryptolib.common.MacSupplier;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.Mac;
 import javax.crypto.ShortBufferException;
 import javax.crypto.spec.IvParameterSpec;
 import java.nio.ByteBuffer;

--- a/src/main/java/org/cryptomator/cryptolib/v1/FileHeaderCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v1/FileHeaderCryptorImpl.java
@@ -62,7 +62,7 @@ class FileHeaderCryptorImpl implements FileHeaderCryptor {
 			result.put(headerImpl.getNonce());
 
 			// encrypt payload:
-			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_CTR.encrypt(ek, new IvParameterSpec(headerImpl.getNonce()))) {
+			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_CTR.encryptionCipher(ek, new IvParameterSpec(headerImpl.getNonce()))) {
 				int encrypted = cipher.get().doFinal(payloadCleartextBuf, result);
 				assert encrypted == FileHeaderImpl.Payload.SIZE;
 			}
@@ -117,7 +117,7 @@ class FileHeaderCryptorImpl implements FileHeaderCryptor {
 		ByteBuffer payloadCleartextBuf = ByteBuffer.allocate(FileHeaderImpl.Payload.SIZE);
 		try (DestroyableSecretKey ek = masterkey.getEncKey()) {
 			// decrypt payload:
-			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_CTR.decrypt(ek, new IvParameterSpec(nonce))) {
+			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_CTR.decryptionCipher(ek, new IvParameterSpec(nonce))) {
 				assert cipher.get().getOutputSize(ciphertextPayload.length) == payloadCleartextBuf.remaining();
 				int decrypted = cipher.get().doFinal(ByteBuffer.wrap(ciphertextPayload), payloadCleartextBuf);
 				assert decrypted == FileHeaderImpl.Payload.SIZE;

--- a/src/main/java/org/cryptomator/cryptolib/v1/FileHeaderCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v1/FileHeaderCryptorImpl.java
@@ -115,7 +115,7 @@ class FileHeaderCryptorImpl implements FileHeaderCryptor {
 		ByteBuffer payloadCleartextBuf = ByteBuffer.allocate(FileHeaderImpl.Payload.SIZE);
 		try (DestroyableSecretKey ek = masterkey.getEncKey()) {
 			// decrypt payload:
-			try (CipherSupplier.ReusableCipher cipher = CipherSupplier.AES_CTR.encrypt(ek, new IvParameterSpec(nonce))) {
+			try (CipherSupplier.ReusableCipher cipher = CipherSupplier.AES_CTR.decrypt(ek, new IvParameterSpec(nonce))) {
 				assert cipher.get().getOutputSize(ciphertextPayload.length) == payloadCleartextBuf.remaining();
 				int decrypted = cipher.get().doFinal(ByteBuffer.wrap(ciphertextPayload), payloadCleartextBuf);
 				assert decrypted == FileHeaderImpl.Payload.SIZE;

--- a/src/main/java/org/cryptomator/cryptolib/v1/FileNameCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v1/FileNameCryptorImpl.java
@@ -14,10 +14,13 @@ import org.cryptomator.cryptolib.api.FileNameCryptor;
 import org.cryptomator.cryptolib.api.Masterkey;
 import org.cryptomator.cryptolib.common.DestroyableSecretKey;
 import org.cryptomator.cryptolib.common.MessageDigestSupplier;
+import org.cryptomator.cryptolib.common.ObjectPool;
 import org.cryptomator.siv.SivMode;
 import org.cryptomator.siv.UnauthenticCiphertextException;
 
 import javax.crypto.IllegalBlockSizeException;
+
+import java.security.MessageDigest;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -40,7 +43,7 @@ class FileNameCryptorImpl implements FileNameCryptor {
 	@Override
 	public String hashDirectoryId(String cleartextDirectoryId) {
 		try (DestroyableSecretKey ek = masterkey.getEncKey(); DestroyableSecretKey mk = masterkey.getMacKey();
-			MessageDigestSupplier.ReusableMessageDigest sha1 = MessageDigestSupplier.SHA1.instance()) {
+			 ObjectPool.Lease<MessageDigest> sha1 = MessageDigestSupplier.SHA1.instance()) {
 			byte[] cleartextBytes = cleartextDirectoryId.getBytes(UTF_8);
 			byte[] encryptedBytes = AES_SIV.get().encrypt(ek, mk, cleartextBytes);
 			byte[] hashedBytes = sha1.get().digest(encryptedBytes);

--- a/src/main/java/org/cryptomator/cryptolib/v1/FileNameCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v1/FileNameCryptorImpl.java
@@ -39,10 +39,11 @@ class FileNameCryptorImpl implements FileNameCryptor {
 
 	@Override
 	public String hashDirectoryId(String cleartextDirectoryId) {
-		try (DestroyableSecretKey ek = masterkey.getEncKey(); DestroyableSecretKey mk = masterkey.getMacKey()) {
+		try (DestroyableSecretKey ek = masterkey.getEncKey(); DestroyableSecretKey mk = masterkey.getMacKey();
+			MessageDigestSupplier.ReusableMessageDigest sha1 = MessageDigestSupplier.SHA1.instance()) {
 			byte[] cleartextBytes = cleartextDirectoryId.getBytes(UTF_8);
 			byte[] encryptedBytes = AES_SIV.get().encrypt(ek, mk, cleartextBytes);
-			byte[] hashedBytes = MessageDigestSupplier.SHA1.get().digest(encryptedBytes);
+			byte[] hashedBytes = sha1.get().digest(encryptedBytes);
 			return BASE32.encode(hashedBytes);
 		}
 	}

--- a/src/main/java/org/cryptomator/cryptolib/v2/FileContentCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v2/FileContentCryptorImpl.java
@@ -16,7 +16,6 @@ import org.cryptomator.cryptolib.common.DestroyableSecretKey;
 
 import javax.crypto.AEADBadTagException;
 import javax.crypto.BadPaddingException;
-import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.ShortBufferException;
 import javax.crypto.spec.GCMParameterSpec;

--- a/src/main/java/org/cryptomator/cryptolib/v2/FileContentCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v2/FileContentCryptorImpl.java
@@ -104,7 +104,7 @@ class FileContentCryptorImpl implements FileContentCryptor {
 			random.nextBytes(nonce);
 
 			// payload:
-			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_GCM.encrypt(fk, new GCMParameterSpec(GCM_TAG_SIZE * Byte.SIZE, nonce))) {
+			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_GCM.encryptionCipher(fk, new GCMParameterSpec(GCM_TAG_SIZE * Byte.SIZE, nonce))) {
 				final byte[] chunkNumberBigEndian = longToBigEndianByteArray(chunkNumber);
 				cipher.get().updateAAD(chunkNumberBigEndian);
 				cipher.get().updateAAD(headerNonce);
@@ -136,7 +136,7 @@ class FileContentCryptorImpl implements FileContentCryptor {
 			assert payloadBuf.remaining() >= GCM_TAG_SIZE;
 
 			// payload:
-			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_GCM.decrypt(fk, new GCMParameterSpec(GCM_TAG_SIZE * Byte.SIZE, nonce))) {
+			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_GCM.decryptionCipher(fk, new GCMParameterSpec(GCM_TAG_SIZE * Byte.SIZE, nonce))) {
 				final byte[] chunkNumberBigEndian = longToBigEndianByteArray(chunkNumber);
 				cipher.get().updateAAD(chunkNumberBigEndian);
 				cipher.get().updateAAD(headerNonce);

--- a/src/main/java/org/cryptomator/cryptolib/v2/FileHeaderCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v2/FileHeaderCryptorImpl.java
@@ -62,7 +62,7 @@ class FileHeaderCryptorImpl implements FileHeaderCryptor {
 			result.put(headerImpl.getNonce());
 
 			// encrypt payload:
-			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_GCM.encrypt(ek, new GCMParameterSpec(GCM_TAG_SIZE * Byte.SIZE, headerImpl.getNonce()))) {
+			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_GCM.encryptionCipher(ek, new GCMParameterSpec(GCM_TAG_SIZE * Byte.SIZE, headerImpl.getNonce()))) {
 				int encrypted = cipher.get().doFinal(payloadCleartextBuf, result);
 				assert encrypted == FileHeaderImpl.PAYLOAD_LEN + FileHeaderImpl.TAG_LEN;
 			}
@@ -94,7 +94,7 @@ class FileHeaderCryptorImpl implements FileHeaderCryptor {
 		ByteBuffer payloadCleartextBuf = ByteBuffer.allocate(FileHeaderImpl.Payload.SIZE + GCM_TAG_SIZE);
 		try (DestroyableSecretKey ek = masterkey.getEncKey()) {
 			// decrypt payload:
-			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_GCM.decrypt(ek, new GCMParameterSpec(GCM_TAG_SIZE * Byte.SIZE, nonce))) {
+			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_GCM.decryptionCipher(ek, new GCMParameterSpec(GCM_TAG_SIZE * Byte.SIZE, nonce))) {
 				int decrypted = cipher.get().doFinal(ByteBuffer.wrap(ciphertextAndTag), payloadCleartextBuf);
 				assert decrypted == FileHeaderImpl.Payload.SIZE;
 			}

--- a/src/main/java/org/cryptomator/cryptolib/v2/FileHeaderCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v2/FileHeaderCryptorImpl.java
@@ -17,7 +17,6 @@ import org.cryptomator.cryptolib.common.DestroyableSecretKey;
 
 import javax.crypto.AEADBadTagException;
 import javax.crypto.BadPaddingException;
-import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.ShortBufferException;
 import javax.crypto.spec.GCMParameterSpec;

--- a/src/main/java/org/cryptomator/cryptolib/v2/FileNameCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v2/FileNameCryptorImpl.java
@@ -14,10 +14,13 @@ import org.cryptomator.cryptolib.api.FileNameCryptor;
 import org.cryptomator.cryptolib.api.Masterkey;
 import org.cryptomator.cryptolib.common.DestroyableSecretKey;
 import org.cryptomator.cryptolib.common.MessageDigestSupplier;
+import org.cryptomator.cryptolib.common.ObjectPool;
 import org.cryptomator.siv.SivMode;
 import org.cryptomator.siv.UnauthenticCiphertextException;
 
 import javax.crypto.IllegalBlockSizeException;
+
+import java.security.MessageDigest;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -40,7 +43,7 @@ class FileNameCryptorImpl implements FileNameCryptor {
 	@Override
 	public String hashDirectoryId(String cleartextDirectoryId) {
 		try (DestroyableSecretKey ek = masterkey.getEncKey(); DestroyableSecretKey mk = masterkey.getMacKey();
-			 MessageDigestSupplier.ReusableMessageDigest sha1 = MessageDigestSupplier.SHA1.instance()) {
+			 ObjectPool.Lease<MessageDigest> sha1 = MessageDigestSupplier.SHA1.instance()) {
 			byte[] cleartextBytes = cleartextDirectoryId.getBytes(UTF_8);
 			byte[] encryptedBytes = AES_SIV.get().encrypt(ek, mk, cleartextBytes);
 			byte[] hashedBytes = sha1.get().digest(encryptedBytes);

--- a/src/main/java/org/cryptomator/cryptolib/v2/FileNameCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v2/FileNameCryptorImpl.java
@@ -39,10 +39,11 @@ class FileNameCryptorImpl implements FileNameCryptor {
 
 	@Override
 	public String hashDirectoryId(String cleartextDirectoryId) {
-		try (DestroyableSecretKey ek = masterkey.getEncKey(); DestroyableSecretKey mk = masterkey.getMacKey()) {
+		try (DestroyableSecretKey ek = masterkey.getEncKey(); DestroyableSecretKey mk = masterkey.getMacKey();
+			 MessageDigestSupplier.ReusableMessageDigest sha1 = MessageDigestSupplier.SHA1.instance()) {
 			byte[] cleartextBytes = cleartextDirectoryId.getBytes(UTF_8);
 			byte[] encryptedBytes = AES_SIV.get().encrypt(ek, mk, cleartextBytes);
-			byte[] hashedBytes = MessageDigestSupplier.SHA1.get().digest(encryptedBytes);
+			byte[] hashedBytes = sha1.get().digest(encryptedBytes);
 			return BASE32.encode(hashedBytes);
 		}
 	}

--- a/src/test/java/org/cryptomator/cryptolib/common/CipherSupplierTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/common/CipherSupplierTest.java
@@ -31,7 +31,7 @@ public class CipherSupplierTest {
 	public void testGetCipherWithInvalidKey() {
 		CipherSupplier supplier = new CipherSupplier("AES/CBC/PKCS5Padding");
 		IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
-			supplier.forEncryption(new DestroyableSecretKey(new byte[13], "AES"), new IvParameterSpec(new byte[16]));
+			supplier.encrypt(new DestroyableSecretKey(new byte[13], "AES"), new IvParameterSpec(new byte[16]));
 		});
 		MatcherAssert.assertThat(exception.getMessage(), CoreMatchers.containsString("Invalid key"));
 	}
@@ -40,7 +40,7 @@ public class CipherSupplierTest {
 	public void testGetCipherWithInvalidAlgorithmParam() {
 		CipherSupplier supplier = new CipherSupplier("AES/CBC/PKCS5Padding");
 		IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
-			supplier.forEncryption(new DestroyableSecretKey(new byte[16], "AES"), new RC5ParameterSpec(1, 1, 8));
+			supplier.encrypt(new DestroyableSecretKey(new byte[16], "AES"), new RC5ParameterSpec(1, 1, 8));
 		});
 		MatcherAssert.assertThat(exception.getMessage(), CoreMatchers.containsString("Algorithm parameter not appropriate for"));
 	}

--- a/src/test/java/org/cryptomator/cryptolib/common/CipherSupplierTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/common/CipherSupplierTest.java
@@ -13,10 +13,8 @@ import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.RC5ParameterSpec;
-import javax.crypto.spec.SecretKeySpec;
 
 public class CipherSupplierTest {
 
@@ -31,7 +29,7 @@ public class CipherSupplierTest {
 	public void testGetCipherWithInvalidKey() {
 		CipherSupplier supplier = new CipherSupplier("AES/CBC/PKCS5Padding");
 		IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
-			supplier.encrypt(new DestroyableSecretKey(new byte[13], "AES"), new IvParameterSpec(new byte[16]));
+			supplier.encryptionCipher(new DestroyableSecretKey(new byte[13], "AES"), new IvParameterSpec(new byte[16]));
 		});
 		MatcherAssert.assertThat(exception.getMessage(), CoreMatchers.containsString("Invalid key"));
 	}
@@ -40,7 +38,7 @@ public class CipherSupplierTest {
 	public void testGetCipherWithInvalidAlgorithmParam() {
 		CipherSupplier supplier = new CipherSupplier("AES/CBC/PKCS5Padding");
 		IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
-			supplier.encrypt(new DestroyableSecretKey(new byte[16], "AES"), new RC5ParameterSpec(1, 1, 8));
+			supplier.encryptionCipher(new DestroyableSecretKey(new byte[16], "AES"), new RC5ParameterSpec(1, 1, 8));
 		});
 		MatcherAssert.assertThat(exception.getMessage(), CoreMatchers.containsString("Algorithm parameter not appropriate for"));
 	}

--- a/src/test/java/org/cryptomator/cryptolib/common/CipherSupplierTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/common/CipherSupplierTest.java
@@ -31,7 +31,7 @@ public class CipherSupplierTest {
 	public void testGetCipherWithInvalidKey() {
 		CipherSupplier supplier = new CipherSupplier("AES/CBC/PKCS5Padding");
 		IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
-			supplier.forMode(Cipher.ENCRYPT_MODE, new DestroyableSecretKey(new byte[13], "AES"), new IvParameterSpec(new byte[16]));
+			supplier.forEncryption(new DestroyableSecretKey(new byte[13], "AES"), new IvParameterSpec(new byte[16]));
 		});
 		MatcherAssert.assertThat(exception.getMessage(), CoreMatchers.containsString("Invalid key"));
 	}
@@ -40,7 +40,7 @@ public class CipherSupplierTest {
 	public void testGetCipherWithInvalidAlgorithmParam() {
 		CipherSupplier supplier = new CipherSupplier("AES/CBC/PKCS5Padding");
 		IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
-			supplier.forMode(Cipher.ENCRYPT_MODE, new DestroyableSecretKey(new byte[16], "AES"), new RC5ParameterSpec(1, 1, 8));
+			supplier.forEncryption(new DestroyableSecretKey(new byte[16], "AES"), new RC5ParameterSpec(1, 1, 8));
 		});
 		MatcherAssert.assertThat(exception.getMessage(), CoreMatchers.containsString("Algorithm parameter not appropriate for"));
 	}

--- a/src/test/java/org/cryptomator/cryptolib/common/MacSupplierTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/common/MacSupplierTest.java
@@ -11,11 +11,9 @@ package org.cryptomator.cryptolib.common;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.lang.reflect.Method;
-import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
@@ -24,27 +22,28 @@ public class MacSupplierTest {
 
 	@Test
 	public void testConstructorWithInvalidDigest() {
-		SecretKey key = new SecretKeySpec(new byte[16], "HmacSHA256");
 		Assertions.assertThrows(IllegalArgumentException.class, () -> {
-			new MacSupplier("FOO3000").withKey(key);
+			new MacSupplier("FOO3000");
 		});
 	}
 
 	@Test
-	public void testGetMac() throws InvalidKeyException, NoSuchAlgorithmException {
+	public void testGetMac() {
 		SecretKey key = new SecretKeySpec(new byte[16], "HmacSHA256");
-		Mac mac1 = MacSupplier.HMAC_SHA256.withKey(key);
-		Assertions.assertNotNull(mac1);
+		try (MacSupplier.ReusableMac mac1 = MacSupplier.HMAC_SHA256.keyed(key)) {
+			Assertions.assertNotNull(mac1);
+		}
 
-		Mac mac2 = MacSupplier.HMAC_SHA256.withKey(key);
-		Assertions.assertSame(mac1, mac2);
+		try (MacSupplier.ReusableMac mac2 = MacSupplier.HMAC_SHA256.keyed(key)) {
+			Assertions.assertNotNull(mac2);
+		}
 	}
 
 	@Test
-	public void testGetMacWithInvalidKey() throws InvalidKeyException, NoSuchAlgorithmException, ReflectiveOperationException {
+	public void testGetMacWithInvalidKey() throws NoSuchAlgorithmException, ReflectiveOperationException {
 		Key key = KeyPairGenerator.getInstance("RSA").generateKeyPair().getPrivate();
 		// invoked via reflection, as we can not cast Key to SecretKey.
-		Method m = MacSupplier.class.getMethod("withKey", SecretKey.class);
+		Method m = MacSupplier.class.getMethod("keyed", SecretKey.class);
 		Assertions.assertThrows(IllegalArgumentException.class, () -> {
 			m.invoke(MacSupplier.HMAC_SHA256, key);
 		});

--- a/src/test/java/org/cryptomator/cryptolib/common/MacSupplierTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/common/MacSupplierTest.java
@@ -11,6 +11,7 @@ package org.cryptomator.cryptolib.common;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.lang.reflect.Method;
@@ -30,11 +31,11 @@ public class MacSupplierTest {
 	@Test
 	public void testGetMac() {
 		SecretKey key = new SecretKeySpec(new byte[16], "HmacSHA256");
-		try (MacSupplier.ReusableMac mac1 = MacSupplier.HMAC_SHA256.keyed(key)) {
+		try (ObjectPool.Lease<Mac> mac1 = MacSupplier.HMAC_SHA256.keyed(key)) {
 			Assertions.assertNotNull(mac1);
 		}
 
-		try (MacSupplier.ReusableMac mac2 = MacSupplier.HMAC_SHA256.keyed(key)) {
+		try (ObjectPool.Lease<Mac> mac2 = MacSupplier.HMAC_SHA256.keyed(key)) {
 			Assertions.assertNotNull(mac2);
 		}
 	}

--- a/src/test/java/org/cryptomator/cryptolib/common/MessageDigestSupplierTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/common/MessageDigestSupplierTest.java
@@ -11,6 +11,8 @@ package org.cryptomator.cryptolib.common;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.security.MessageDigest;
+
 public class MessageDigestSupplierTest {
 
 	@Test
@@ -22,11 +24,11 @@ public class MessageDigestSupplierTest {
 
 	@Test
 	public void testGetSha1() {
-		try (MessageDigestSupplier.ReusableMessageDigest digest = MessageDigestSupplier.SHA1.instance()) {
+		try (ObjectPool.Lease<MessageDigest> digest = MessageDigestSupplier.SHA1.instance()) {
 			Assertions.assertNotNull(digest);
 		}
 
-		try (MessageDigestSupplier.ReusableMessageDigest digest = MessageDigestSupplier.SHA1.instance()) {
+		try (ObjectPool.Lease<MessageDigest> digest = MessageDigestSupplier.SHA1.instance()) {
 			Assertions.assertNotNull(digest);
 		}
 	}

--- a/src/test/java/org/cryptomator/cryptolib/common/MessageDigestSupplierTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/common/MessageDigestSupplierTest.java
@@ -11,24 +11,24 @@ package org.cryptomator.cryptolib.common;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.security.MessageDigest;
-
 public class MessageDigestSupplierTest {
 
 	@Test
 	public void testConstructorWithInvalidDigest() {
 		Assertions.assertThrows(IllegalArgumentException.class, () -> {
-			new MessageDigestSupplier("FOO3000").get();
+			new MessageDigestSupplier("FOO3000");
 		});
 	}
 
 	@Test
 	public void testGetSha1() {
-		MessageDigest digest1 = MessageDigestSupplier.SHA1.get();
-		Assertions.assertNotNull(digest1);
+		try (MessageDigestSupplier.ReusableMessageDigest digest = MessageDigestSupplier.SHA1.instance()) {
+			Assertions.assertNotNull(digest);
+		}
 
-		MessageDigest digest2 = MessageDigestSupplier.SHA1.get();
-		Assertions.assertSame(digest1, digest2);
+		try (MessageDigestSupplier.ReusableMessageDigest digest = MessageDigestSupplier.SHA1.instance()) {
+			Assertions.assertNotNull(digest);
+		}
 	}
 
 }

--- a/src/test/java/org/cryptomator/cryptolib/common/ObjectPoolTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/common/ObjectPoolTest.java
@@ -21,8 +21,8 @@ public class ObjectPoolTest {
 	@Test
 	@DisplayName("new instance is created if pool is empty")
 	public void testCreateNewObjWhenPoolIsEmpty() {
-		try (ObjectPool<Foo>.Lease lease1 = pool.get()) {
-			try (ObjectPool<Foo>.Lease lease2 = pool.get()) {
+		try (ObjectPool.Lease<Foo> lease1 = pool.get()) {
+			try (ObjectPool.Lease<Foo> lease2 = pool.get()) {
 				Assertions.assertNotSame(lease1.get(), lease2.get());
 			}
 		}
@@ -33,10 +33,10 @@ public class ObjectPoolTest {
 	@DisplayName("recycle existing instance")
 	public void testRecycleExistingObj() {
 		Foo foo1;
-		try (ObjectPool<Foo>.Lease lease = pool.get()) {
+		try (ObjectPool.Lease<Foo> lease = pool.get()) {
 			foo1 = lease.get();
 		}
-		try (ObjectPool<Foo>.Lease lease = pool.get()) {
+		try (ObjectPool.Lease<Foo> lease = pool.get()) {
 			Assertions.assertSame(foo1, lease.get());
 		}
 		Mockito.verify(factory, Mockito.times(1)).get();
@@ -45,11 +45,11 @@ public class ObjectPoolTest {
 	@Test
 	@DisplayName("create new instance when pool is GC'ed")
 	public void testGc() {
-		try (ObjectPool<Foo>.Lease lease = pool.get()) {
+		try (ObjectPool.Lease<Foo> lease = pool.get()) {
 			Assertions.assertNotNull(lease.get());
 		}
 		System.gc(); // seems to be reliable on Temurin 17 with @RepeatedTest(1000)
-		try (ObjectPool<Foo>.Lease lease = pool.get()) {
+		try (ObjectPool.Lease<Foo> lease = pool.get()) {
 			Assertions.assertNotNull(lease.get());
 		}
 		Mockito.verify(factory, Mockito.times(2)).get();

--- a/src/test/java/org/cryptomator/cryptolib/common/ObjectPoolTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/common/ObjectPoolTest.java
@@ -1,0 +1,61 @@
+package org.cryptomator.cryptolib.common;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.function.Supplier;
+
+public class ObjectPoolTest {
+
+	private Supplier<Foo> factory = Mockito.mock(Supplier.class);
+	private ObjectPool<Foo> pool = new ObjectPool<>(factory);
+
+	@BeforeEach
+	public void setup() {
+		Mockito.doAnswer(invocation -> new Foo()).when(factory).get();
+	}
+
+	@Test
+	@DisplayName("new instance is created if pool is empty")
+	public void testCreateNewObjWhenPoolIsEmpty() {
+		try (ObjectPool<Foo>.Lease lease1 = pool.get()) {
+			try (ObjectPool<Foo>.Lease lease2 = pool.get()) {
+				Assertions.assertNotSame(lease1.get(), lease2.get());
+			}
+		}
+		Mockito.verify(factory, Mockito.times(2)).get();
+	}
+
+	@Test
+	@DisplayName("recycle existing instance")
+	public void testRecycleExistingObj() {
+		Foo foo1;
+		try (ObjectPool<Foo>.Lease lease = pool.get()) {
+			foo1 = lease.get();
+		}
+		try (ObjectPool<Foo>.Lease lease = pool.get()) {
+			Assertions.assertSame(foo1, lease.get());
+		}
+		Mockito.verify(factory, Mockito.times(1)).get();
+	}
+
+	@Test
+	@DisplayName("create new instance when pool is GC'ed")
+	public void testGc() {
+		try (ObjectPool<Foo>.Lease lease = pool.get()) {
+			Assertions.assertNotNull(lease.get());
+		}
+		System.gc(); // seems to be reliable on Temurin 17 with @RepeatedTest(1000)
+		try (ObjectPool<Foo>.Lease lease = pool.get()) {
+			Assertions.assertNotNull(lease.get());
+		}
+		Mockito.verify(factory, Mockito.times(2)).get();
+	}
+
+	private static class Foo {
+	}
+
+}

--- a/src/test/java/org/cryptomator/cryptolib/common/PooledSuppliersBenchmarkTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/common/PooledSuppliersBenchmarkTest.java
@@ -1,0 +1,99 @@
+package org.cryptomator.cryptolib.common;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import javax.crypto.Cipher;
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.MessageDigest;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Thread)
+@Warmup(iterations = 2)
+@Measurement(iterations = 2)
+@BenchmarkMode(value = {Mode.AverageTime})
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class PooledSuppliersBenchmarkTest {
+
+	private static final Random RNG = new Random(42);
+	private static final CipherSupplier CIPHER_SUPPLIER = CipherSupplier.AES_GCM;
+	private static final MessageDigestSupplier MD_SUPPLIER = MessageDigestSupplier.SHA256;
+	private static final MacSupplier MAC_SUPPLIER = MacSupplier.HMAC_SHA256;
+	private SecretKey key;
+	private GCMParameterSpec gcmParams;
+
+	@Disabled("only on demand")
+	@Test
+	public void runBenchmarks() throws RunnerException {
+		Options opt = new OptionsBuilder() //
+				.include(getClass().getName()) //
+				.threads(2).forks(1) //
+				.shouldFailOnError(true).shouldDoGC(true) //
+				.build();
+		new Runner(opt).run();
+	}
+
+	@Setup(Level.Invocation)
+	public void shuffleData() {
+		byte[] bytes = new byte[28];
+		RNG.nextBytes(bytes);
+		this.key = new SecretKeySpec(bytes, 0, 16, "AES");
+		this.gcmParams = new GCMParameterSpec(128, bytes, 16, 12);
+	}
+
+	@Benchmark
+	public void createCipher(Blackhole blackHole) {
+		blackHole.consume(CIPHER_SUPPLIER.forEncryption(key, gcmParams));
+	}
+
+	@Benchmark
+	public void recycleCipher(Blackhole blackHole) {
+		try (ObjectPool.Lease<Cipher> lease = CIPHER_SUPPLIER.encryptionCipher(key, gcmParams)) {
+			blackHole.consume(lease.get());
+		}
+	}
+
+	@Benchmark
+	public void createMac(Blackhole blackHole) {
+		blackHole.consume(MAC_SUPPLIER.withKey(key));
+	}
+
+	@Benchmark
+	public void recycleMac(Blackhole blackHole) {
+		try (ObjectPool.Lease<Mac> lease = MAC_SUPPLIER.keyed(key)) {
+			blackHole.consume(lease.get());
+		}
+	}
+
+	@Benchmark
+	public void createMd(Blackhole blackHole) {
+		blackHole.consume(MD_SUPPLIER.get());
+	}
+
+	@Benchmark
+	public void recycleMd(Blackhole blackHole) {
+		try (ObjectPool.Lease<MessageDigest> lease = MD_SUPPLIER.instance()) {
+			blackHole.consume(lease.get());
+		}
+	}
+
+}

--- a/src/test/java/org/cryptomator/cryptolib/ecies/GcmWithSecretNonceTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/ecies/GcmWithSecretNonceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.params.converter.ConvertWith;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import javax.crypto.AEADBadTagException;
+import javax.crypto.spec.GCMParameterSpec;
 
 /**
  * Test vectors from https://csrc.nist.rip/groups/ST/toolkit/BCM/documents/proposedmodes/gcm/gcm-spec.pdf
@@ -22,7 +23,9 @@ public class GcmWithSecretNonceTest {
 	public void setup() {
 		// reset cipher state to avoid InvalidAlgorithmParameterExceptions due to IV-reuse
 		GcmTestHelper.reset((mode, key, params) -> {
-			CipherSupplier.AES_GCM.forEncryption(key, params);
+			try (CipherSupplier.ReusableCipher cipher = CipherSupplier.AES_GCM.encrypt(key, params)) {
+				cipher.get();
+			}
 		});
 	}
 

--- a/src/test/java/org/cryptomator/cryptolib/ecies/GcmWithSecretNonceTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/ecies/GcmWithSecretNonceTest.java
@@ -2,6 +2,7 @@ package org.cryptomator.cryptolib.ecies;
 
 import org.cryptomator.cryptolib.common.CipherSupplier;
 import org.cryptomator.cryptolib.common.GcmTestHelper;
+import org.cryptomator.cryptolib.common.ObjectPool;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,6 +11,7 @@ import org.junit.jupiter.params.converter.ConvertWith;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import javax.crypto.AEADBadTagException;
+import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
 
 /**
@@ -23,7 +25,7 @@ public class GcmWithSecretNonceTest {
 	public void setup() {
 		// reset cipher state to avoid InvalidAlgorithmParameterExceptions due to IV-reuse
 		GcmTestHelper.reset((mode, key, params) -> {
-			try (CipherSupplier.ReusableCipher cipher = CipherSupplier.AES_GCM.encrypt(key, params)) {
+			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_GCM.encrypt(key, params)) {
 				cipher.get();
 			}
 		});

--- a/src/test/java/org/cryptomator/cryptolib/ecies/GcmWithSecretNonceTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/ecies/GcmWithSecretNonceTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 import javax.crypto.AEADBadTagException;
 import javax.crypto.Cipher;
-import javax.crypto.spec.GCMParameterSpec;
 
 /**
  * Test vectors from https://csrc.nist.rip/groups/ST/toolkit/BCM/documents/proposedmodes/gcm/gcm-spec.pdf
@@ -25,7 +24,7 @@ public class GcmWithSecretNonceTest {
 	public void setup() {
 		// reset cipher state to avoid InvalidAlgorithmParameterExceptions due to IV-reuse
 		GcmTestHelper.reset((mode, key, params) -> {
-			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_GCM.encrypt(key, params)) {
+			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_GCM.encryptionCipher(key, params)) {
 				cipher.get();
 			}
 		});

--- a/src/test/java/org/cryptomator/cryptolib/v2/FileHeaderCryptorImplTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/v2/FileHeaderCryptorImplTest.java
@@ -21,11 +21,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.crypto.Cipher;
-import javax.crypto.spec.GCMParameterSpec;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
-
-import static org.cryptomator.cryptolib.v2.Constants.GCM_TAG_SIZE;
 
 public class FileHeaderCryptorImplTest {
 
@@ -40,7 +37,7 @@ public class FileHeaderCryptorImplTest {
 
 		// reset cipher state to avoid InvalidAlgorithmParameterExceptions due to IV-reuse
 		GcmTestHelper.reset((mode, key, params) -> {
-			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_GCM.encrypt(key, params)) {
+			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_GCM.encryptionCipher(key, params)) {
 				cipher.get();
 			}
 		});

--- a/src/test/java/org/cryptomator/cryptolib/v2/FileHeaderCryptorImplTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/v2/FileHeaderCryptorImplTest.java
@@ -19,8 +19,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.crypto.spec.GCMParameterSpec;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
+
+import static org.cryptomator.cryptolib.v2.Constants.GCM_TAG_SIZE;
 
 public class FileHeaderCryptorImplTest {
 
@@ -35,7 +38,9 @@ public class FileHeaderCryptorImplTest {
 
 		// reset cipher state to avoid InvalidAlgorithmParameterExceptions due to IV-reuse
 		GcmTestHelper.reset((mode, key, params) -> {
-			CipherSupplier.AES_GCM.forEncryption(key, params);
+			try (CipherSupplier.ReusableCipher cipher = CipherSupplier.AES_GCM.encrypt(key, params)) {
+				cipher.get();
+			}
 		});
 	}
 

--- a/src/test/java/org/cryptomator/cryptolib/v2/FileHeaderCryptorImplTest.java
+++ b/src/test/java/org/cryptomator/cryptolib/v2/FileHeaderCryptorImplTest.java
@@ -14,11 +14,13 @@ import org.cryptomator.cryptolib.api.FileHeader;
 import org.cryptomator.cryptolib.api.Masterkey;
 import org.cryptomator.cryptolib.common.CipherSupplier;
 import org.cryptomator.cryptolib.common.GcmTestHelper;
+import org.cryptomator.cryptolib.common.ObjectPool;
 import org.cryptomator.cryptolib.common.SecureRandomMock;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
@@ -38,7 +40,7 @@ public class FileHeaderCryptorImplTest {
 
 		// reset cipher state to avoid InvalidAlgorithmParameterExceptions due to IV-reuse
 		GcmTestHelper.reset((mode, key, params) -> {
-			try (CipherSupplier.ReusableCipher cipher = CipherSupplier.AES_GCM.encrypt(key, params)) {
+			try (ObjectPool.Lease<Cipher> cipher = CipherSupplier.AES_GCM.encrypt(key, params)) {
 				cipher.get();
 			}
 		});


### PR DESCRIPTION
We used to use `ThreadLocal<Cipher>` instances, so we can reuse Cipher instances, as creating new Ciphers is fairly expensive due to ServiceLoaders involved (especially on older JREs).

Normally, if a thread is no longer alive, the ThreadLocals are removed. However, if the thread is re-used, the ThreadLocal may leak.

This PR replaces ThreadLocals with [ObjectPool](https://github.com/cryptomator/cryptolib/blob/a0954d48548da1701aa3d37dde1bb200271636ce/src/main/java/org/cryptomator/cryptolib/common/ObjectPool.java)s which allow rapid re-use of Ciphers (even across threads) while still allowing them to be garbage collected.

This comes with a small performance penalty, though:

```
Benchmark                    Mode  Cnt  Score   Error  Units
Uncached createCipher        avgt    2  6,045          us/op
Uncached createMac           avgt    2  1,058          us/op
Uncached createMd            avgt    2  0,159          us/op
ThreadLocal createCipher     avgt    2  1,455          us/op
ThreadLocal createMac        avgt    2  0,186          us/op
ThreadLocal createMd         avgt    2  0,085          us/op
Pooled recycleCipher         avgt    2  1,753          us/op
Pooled recycleMac            avgt    2  0,401          us/op
Pooled recycleMd             avgt    2  0,244          us/op
```