### PR TITLE
Avoid `ByteBuffer#asReadOnlyBuffer()`

### DIFF
--- a/src/main/java/org/cryptomator/cryptolib/v1/FileContentCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v1/FileContentCryptorImpl.java
@@ -115,9 +115,9 @@ class FileContentCryptorImpl implements FileContentCryptor {
 			int bytesEncrypted = cipher.doFinal(cleartextChunk, ciphertextChunk);
 
 			// mac:
-			final ByteBuffer ciphertextBuf = ciphertextChunk.asReadOnlyBuffer();
-			ciphertextBuf.position(NONCE_SIZE).limit(NONCE_SIZE + bytesEncrypted);
-			byte[] authenticationCode = calcChunkMac(headerNonce, chunkNumber, nonce, ciphertextBuf);
+			ByteBuffer nonceAndPayload = ciphertextChunk.duplicate();
+			nonceAndPayload.flip();
+			byte[] authenticationCode = calcChunkMac(headerNonce, chunkNumber, nonceAndPayload);
 			assert authenticationCode.length == MAC_SIZE;
 			ciphertextChunk.put(authenticationCode);
 		} catch (ShortBufferException e) {
@@ -134,12 +134,10 @@ class FileContentCryptorImpl implements FileContentCryptor {
 		try (DestroyableSecretKey fk = fileKey.copy()) {
 			// nonce:
 			final byte[] nonce = new byte[NONCE_SIZE];
-			final ByteBuffer chunkNonceBuf = ciphertextChunk.asReadOnlyBuffer();
-			chunkNonceBuf.position(0).limit(NONCE_SIZE);
-			chunkNonceBuf.get(nonce);
+			ciphertextChunk.get(nonce, 0, NONCE_SIZE);
 
 			// payload:
-			final ByteBuffer payloadBuf = ciphertextChunk.asReadOnlyBuffer();
+			final ByteBuffer payloadBuf = ciphertextChunk.duplicate();
 			payloadBuf.position(NONCE_SIZE).limit(ciphertextChunk.limit() - MAC_SIZE);
 
 			// payload:
@@ -157,37 +155,30 @@ class FileContentCryptorImpl implements FileContentCryptor {
 	boolean checkChunkMac(byte[] headerNonce, long chunkNumber, ByteBuffer chunkBuf) {
 		assert chunkBuf.remaining() >= NONCE_SIZE + MAC_SIZE;
 
-		// get three components: nonce + payload + mac
-		final ByteBuffer chunkNonceBuf = chunkBuf.asReadOnlyBuffer();
-		chunkNonceBuf.position(0).limit(NONCE_SIZE);
-		final ByteBuffer payloadBuf = chunkBuf.asReadOnlyBuffer();
-		payloadBuf.position(NONCE_SIZE).limit(chunkBuf.limit() - MAC_SIZE);
-		final ByteBuffer expectedMacBuf = chunkBuf.asReadOnlyBuffer();
+		// get nonce + payload
+		final ByteBuffer nonceAndPayload = chunkBuf.duplicate();
+		nonceAndPayload.position(0).limit(chunkBuf.limit() - MAC_SIZE);
+		final ByteBuffer expectedMacBuf = chunkBuf.duplicate();
 		expectedMacBuf.position(chunkBuf.limit() - MAC_SIZE);
-
-		// get nonce:
-		final byte[] chunkNonce = new byte[NONCE_SIZE];
-		chunkNonceBuf.get(chunkNonce);
 
 		// get expected MAC:
 		final byte[] expectedMac = new byte[MAC_SIZE];
 		expectedMacBuf.get(expectedMac);
 
 		// get actual MAC:
-		final byte[] calculatedMac = calcChunkMac(headerNonce, chunkNumber, chunkNonce, payloadBuf);
+		final byte[] calculatedMac = calcChunkMac(headerNonce, chunkNumber, nonceAndPayload);
 
 		// time-constant equality check of two MACs:
 		return MessageDigest.isEqual(expectedMac, calculatedMac);
 	}
 
-	private byte[] calcChunkMac(byte[] headerNonce, long chunkNumber, byte[] chunkNonce, ByteBuffer ciphertext) {
+	private byte[] calcChunkMac(byte[] headerNonce, long chunkNumber, ByteBuffer nonceAndCiphertext) {
 		try (DestroyableSecretKey mk = masterkey.getMacKey()) {
 			final byte[] chunkNumberBigEndian = ByteBuffer.allocate(Long.SIZE / Byte.SIZE).order(ByteOrder.BIG_ENDIAN).putLong(chunkNumber).array();
 			final Mac mac = MacSupplier.HMAC_SHA256.withKey(mk);
 			mac.update(headerNonce);
 			mac.update(chunkNumberBigEndian);
-			mac.update(chunkNonce);
-			mac.update(ciphertext);
+			mac.update(nonceAndCiphertext);
 			return mac.doFinal();
 		}
 	}

--- a/src/main/java/org/cryptomator/cryptolib/v1/FileContentCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v1/FileContentCryptorImpl.java
@@ -112,7 +112,7 @@ class FileContentCryptorImpl implements FileContentCryptor {
 			final Cipher cipher = CipherSupplier.AES_CTR.forEncryption(fk, new IvParameterSpec(nonce));
 			ciphertextChunk.put(nonce);
 			assert ciphertextChunk.remaining() >= cipher.getOutputSize(cleartextChunk.remaining()) + MAC_SIZE;
-			int bytesEncrypted = cipher.doFinal(cleartextChunk, ciphertextChunk);
+			cipher.doFinal(cleartextChunk, ciphertextChunk);
 
 			// mac:
 			ByteBuffer nonceAndPayload = ciphertextChunk.duplicate();

--- a/src/main/java/org/cryptomator/cryptolib/v1/FileHeaderCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v1/FileHeaderCryptorImpl.java
@@ -88,7 +88,7 @@ class FileHeaderCryptorImpl implements FileHeaderCryptor {
 		if (ciphertextHeaderBuf.remaining() < FileHeaderImpl.SIZE) {
 			throw new IllegalArgumentException("Malformed ciphertext header");
 		}
-		ByteBuffer buf = ciphertextHeaderBuf.asReadOnlyBuffer();
+		ByteBuffer buf = ciphertextHeaderBuf.duplicate();
 		byte[] nonce = new byte[FileHeaderImpl.NONCE_LEN];
 		buf.position(FileHeaderImpl.NONCE_POS);
 		buf.get(nonce);

--- a/src/main/java/org/cryptomator/cryptolib/v2/FileContentCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v2/FileContentCryptorImpl.java
@@ -124,12 +124,10 @@ class FileContentCryptorImpl implements FileContentCryptor {
 		try (DestroyableSecretKey fk = fileKey.copy()) {
 			// nonce:
 			final byte[] nonce = new byte[GCM_NONCE_SIZE];
-			final ByteBuffer chunkNonceBuf = ciphertextChunk.asReadOnlyBuffer();
-			chunkNonceBuf.position(0).limit(GCM_NONCE_SIZE);
-			chunkNonceBuf.get(nonce);
+			ciphertextChunk.get(nonce, 0, GCM_NONCE_SIZE);
 
 			// payload:
-			final ByteBuffer payloadBuf = ciphertextChunk.asReadOnlyBuffer();
+			final ByteBuffer payloadBuf = ciphertextChunk.duplicate();
 			payloadBuf.position(GCM_NONCE_SIZE);
 			assert payloadBuf.remaining() >= GCM_TAG_SIZE;
 

--- a/src/main/java/org/cryptomator/cryptolib/v2/FileHeaderCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v2/FileHeaderCryptorImpl.java
@@ -81,7 +81,7 @@ class FileHeaderCryptorImpl implements FileHeaderCryptor {
 		if (ciphertextHeaderBuf.remaining() < FileHeaderImpl.SIZE) {
 			throw new IllegalArgumentException("Malformed ciphertext header");
 		}
-		ByteBuffer buf = ciphertextHeaderBuf.asReadOnlyBuffer();
+		ByteBuffer buf = ciphertextHeaderBuf.duplicate();
 		byte[] nonce = new byte[FileHeaderImpl.NONCE_LEN];
 		buf.position(FileHeaderImpl.NONCE_POS);
 		buf.get(nonce);


### PR DESCRIPTION
Except for some cases where a `ReadOnlyBuffer` is used in a very limited scope, we don't want to use them in conjunction with Ciphers and Macs for the following reason:

A readonly buffer doesn't allow direct access to its `byte[]`, regardless of whether its on-heap or not. However, Ciphers are more efficient when `ByteBuffer#hasArray()` returns true ([as can be seen e.g. in `CipherSpi`](https://github.com/openjdk/jdk/blob/a07e19d8336f8fbea8736ba169787aec6d812817/src/java.base/share/classes/javax/crypto/CipherSpi.java#L773-L774)) as they don't need to copy bytes from the buffers to some internal `byte[]`.

To avoid allocations of `byte[]`, we will therefore use `.duplicate()` instead of `.asReadOnlyBuffer()`, even if we don't need write access to said buffers.