### PR TITLE
Update suppression.xml

### DIFF
--- a/suppression.xml
+++ b/suppression.xml
@@ -18,4 +18,36 @@
 		<vulnerabilityName>CVE-2020-8908</vulnerabilityName>
 		<cve>CVE-2020-8908</cve>
 	</suppress>
+	<suppress>
+   		<notes><![CDATA[
+   			file name: bcutil-jdk15on-1.70.jar
+			reason: vulnerable PEMParser not used.
+   		]]></notes>
+   		<packageUrl regex="true">^pkg:maven/org\.bouncycastle/bcutil\-jdk15on@.*$</packageUrl>
+   		<cve>CVE-2023-33202</cve>
+	</suppress>
+	<suppress>
+   		<notes><![CDATA[
+   			file name: bcpkix-jdk15on-1.70.jar
+			reason: vulnerable PEMParser not used.
+   		]]></notes>
+   		<packageUrl regex="true">^pkg:maven/org\.bouncycastle/bcpkix\-jdk15on@.*$</packageUrl>
+   		<cve>CVE-2023-33202</cve>
+	</suppress>
+	<suppress>
+   		<notes><![CDATA[
+   			file name: bcpkix-jdk15on-1.70.jar
+			reason: vulnerable PEMParser not used.
+   		]]></notes>
+   		<packageUrl regex="true">^pkg:maven/org\.bouncycastle/bcpkix\-jdk15on@.*$</packageUrl>
+   		<cve>CVE-2023-33202</cve>
+	</suppress>
+	<suppress>
+   		<notes><![CDATA[
+   			file name: bcprov-jdk15on-1.70.jar
+			reason: Library does not use LDAP CertStore from Bouncy Castle to validate X.509 certificates
+			]]></notes>
+   		<packageUrl regex="true">^pkg:maven/org\.bouncycastle/bcprov\-jdk15on@.*$</packageUrl>
+   		<vulnerabilityName>CVE-2023-33201</vulnerabilityName>
+</suppress>
 </suppressions>

--- a/suppression.xml
+++ b/suppression.xml
@@ -36,12 +36,12 @@
 	</suppress>
 	<suppress>
    		<notes><![CDATA[
-   			file name: bcpkix-jdk15on-1.70.jar
+   			file name: bcprov-jdk15on-1.70.jar
 			reason: vulnerable PEMParser not used.
    		]]></notes>
-   		<packageUrl regex="true">^pkg:maven/org\.bouncycastle/bcpkix\-jdk15on@.*$</packageUrl>
+   		<packageUrl regex="true">^pkg:maven/org\.bouncycastle/bcprov\-jdk15on@.*$</packageUrl>
    		<cve>CVE-2023-33202</cve>
-	</suppress>
+</suppress>
 	<suppress>
    		<notes><![CDATA[
    			file name: bcprov-jdk15on-1.70.jar


### PR DESCRIPTION
Adds CVEs [CVE-2023-33202](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-33202) and [CVE-2023-33201](https://github.com/advisories/GHSA-hr8g-6v94-x4m9) to the suppression file.

Reason: The affected classes/mechanisms are not used.