### PR TITLE
Feature: Update libs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
 		<!-- dependencies -->
 		<gson.version>2.10.1</gson.version>
 		<guava.version>33.1.0-jre</guava.version>
-		<siv-mode.version>1.5.0</siv-mode.version>
-		<bouncycastle.version>1.70</bouncycastle.version>
+		<siv-mode.version>1.5.1</siv-mode.version>
+		<bouncycastle.version>1.78</bouncycastle.version>
 		<slf4j.version>2.0.12</slf4j.version>
 
 		<!-- test dependencies -->
@@ -63,7 +63,7 @@
 
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcpkix-jdk15on</artifactId>
+			<artifactId>bcpkix-jdk18on</artifactId>
 			<version>${bouncycastle.version}</version>
 			<!-- see maven-shade-plugin; we don't want this as a transitive dependency in other projects -->
 			<optional>true</optional>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<!-- dependencies -->
 		<gson.version>2.10.1</gson.version>
 		<guava.version>33.1.0-jre</guava.version>
-		<siv-mode.version>1.5.1</siv-mode.version>
+		<siv-mode.version>1.5.2</siv-mode.version>
 		<bouncycastle.version>1.78</bouncycastle.version>
 		<slf4j.version>2.0.12</slf4j.version>
 

--- a/suppression.xml
+++ b/suppression.xml
@@ -3,8 +3,9 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 	<suppress>
 		<notes><![CDATA[
-        Incorrectly matched CPE
-        ]]></notes>
+			Incorrectly matched CPE
+			]]>
+		</notes>
 		<gav regex="true">org\.cryptomator:.*</gav>
 		<cpe>cpe:/a:cryptomator:cryptomator</cpe>
 		<cve>CVE-2022-25366</cve>
@@ -12,42 +13,11 @@
 
 	<suppress>
 		<notes><![CDATA[
-  		Suppress false positive, because com.google.common.io.Files.getTempDir() is not used
-   ]]></notes>
+			Suppress false positive, because com.google.common.io.Files.getTempDir() is not used
+			]]>
+		</notes>
 		<packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
 		<vulnerabilityName>CVE-2020-8908</vulnerabilityName>
 		<cve>CVE-2020-8908</cve>
 	</suppress>
-	<suppress>
-   		<notes><![CDATA[
-   			file name: bcutil-jdk15on-1.70.jar
-			reason: vulnerable PEMParser not used.
-   		]]></notes>
-   		<packageUrl regex="true">^pkg:maven/org\.bouncycastle/bcutil\-jdk15on@.*$</packageUrl>
-   		<cve>CVE-2023-33202</cve>
-	</suppress>
-	<suppress>
-   		<notes><![CDATA[
-   			file name: bcpkix-jdk15on-1.70.jar
-			reason: vulnerable PEMParser not used.
-   		]]></notes>
-   		<packageUrl regex="true">^pkg:maven/org\.bouncycastle/bcpkix\-jdk15on@.*$</packageUrl>
-   		<cve>CVE-2023-33202</cve>
-	</suppress>
-	<suppress>
-   		<notes><![CDATA[
-   			file name: bcprov-jdk15on-1.70.jar
-			reason: vulnerable PEMParser not used.
-   		]]></notes>
-   		<packageUrl regex="true">^pkg:maven/org\.bouncycastle/bcprov\-jdk15on@.*$</packageUrl>
-   		<cve>CVE-2023-33202</cve>
-</suppress>
-	<suppress>
-   		<notes><![CDATA[
-   			file name: bcprov-jdk15on-1.70.jar
-			reason: Library does not use LDAP CertStore from Bouncy Castle to validate X.509 certificates
-			]]></notes>
-   		<packageUrl regex="true">^pkg:maven/org\.bouncycastle/bcprov\-jdk15on@.*$</packageUrl>
-   		<vulnerabilityName>CVE-2023-33201</vulnerabilityName>
-</suppress>
 </suppressions>


### PR DESCRIPTION
This PR update siv-mode to version 1.5.2 and bouncycastle to version 1.78.

With this updates several suppressed CVEs are fixed, hence, also the suppression file is updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updated Dependencies**
	- Updated `siv-mode` library from version 1.5.0 to 1.5.2.
	- Updated `bouncycastle` library from version 1.70 to 1.78.
	- Changed `bcpkix-jdk15on` to `bcpkix-jdk18on` for enhanced compatibility.

- **Documentation**
	- Improved formatting and alignment in suppression notes for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->